### PR TITLE
Fix row length overflow with long URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hf-mem"
-version = "0.1.0"
+version = "0.1.1"
 description = "A CLI to estimate inference memory requirements for Hugging Face models, written in Python"
 readme = "README.md"
 authors = [

--- a/src/hf_mem/print.py
+++ b/src/hf_mem/print.py
@@ -1,4 +1,5 @@
 import math
+import warnings
 from typing import Any, Dict, Literal, Optional
 
 MIN_NAME_LEN = 5
@@ -107,7 +108,10 @@ def _bytes_to_gb(nbytes: int) -> float:
 
 
 def print_report_for_transformers(
-    model_id: str, revision: str, metadata: Dict[str, Any]
+    model_id: str,
+    revision: str,
+    metadata: Dict[str, Any],
+    ignore_table_width: bool = False,
 ) -> None:
     ppdt = {}
     for key, value in metadata.items():
@@ -149,7 +153,12 @@ def print_report_for_transformers(
     for r in rows:
         max_len = max(max_len, len(str(r)))
 
-    current_len = min(max_len, MAX_DATA_LEN)
+    if max_len > MAX_DATA_LEN and ignore_table_width is False:
+        warnings.warn(
+            f"Given that the provided `--model-id {model_id}` (with `--revision {revision}`) is longer than {MAX_DATA_LEN} characters, the table width will be expanded to fit the provided values within their row, but it might lead to unexpected table views. If you'd like to ignore the limit, then provide the `--ignore-table-width` flag to ignore the {MAX_DATA_LEN} width limit, to simply accommodate to whatever the longest text length is."
+        )
+
+    current_len = min(max_len, MAX_DATA_LEN) if ignore_table_width is False else max_len
 
     total_bytes = sum(nbytes for _, nbytes in ppdt.values())
     total_params = sum(params for params, _ in ppdt.values())
@@ -191,7 +200,10 @@ def print_report_for_transformers(
 
 
 def print_report_for_diffusers(
-    model_id: str, revision: str, metadata: Dict[str, Dict[str, Any]]
+    model_id: str,
+    revision: str,
+    metadata: Dict[str, Dict[str, Any]],
+    ignore_table_width: bool = False,
 ) -> None:
     components_ppdt: Dict[str, Dict[str, tuple[int, int]]] = {}
     total_bytes = 0
@@ -245,7 +257,13 @@ def print_report_for_diffusers(
     max_len = 0
     for r in rows:
         max_len = max(max_len, len(str(r)))
-    current_len = min(max_len, MAX_DATA_LEN)
+
+    if max_len > MAX_DATA_LEN and ignore_table_width is False:
+        warnings.warn(
+            f"Given that the provided `--model-id {model_id}` (with `--revision {revision}`) is longer than {MAX_DATA_LEN} characters, the table width will be expanded to fit the provided values within their row, but it might lead to unexpected table views. If you'd like to ignore the limit, then provide the `--ignore-table-width` flag to ignore the {MAX_DATA_LEN} width limit, to simply accommodate to whatever the longest text length is."
+        )
+
+    current_len = min(max_len, MAX_DATA_LEN) if ignore_table_width is False else max_len
 
     _print_header(current_len)
     _print_centered("INFERENCE MEMORY ESTIMATE FOR", current_len)

--- a/src/hf_mem/print.py
+++ b/src/hf_mem/print.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Literal, Optional
 MIN_NAME_LEN = 5
 MAX_NAME_LEN = 13
 MIN_DATA_LEN = 20
-MAX_DATA_LEN = 32
+MAX_DATA_LEN = 64
 BORDERS_AND_PADDING = 7
 
 BOX = {

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "hf-mem"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", extra = ["http2"] },


### PR DESCRIPTION
## Description

This PR fixes an issue with the default `MAX_DATA_LEN` which was set to 32, meaning that the URL to the Hugging Face Hub and the revision (formatted as `@ {revision}`) should be at most 32 characters, which was failing for some longer model IDs e.g. `HuggingFaceTB/SmolLM2-1.7B-Instruct` as reported by @gabrielmbmb, which is now increased to 64.

Additionally, this PR adds the flag `--ignore-table-width` for cases where the model ID is even longer than that e.g. `DavidAU/Llama3.3-8B-Instruct-Thinking-Claude-4.5-Opus-High-Reasoning`, to let the users decide whether to ignore the default maximum length i.e., table width, in favor of whatever the longest row length is.