### PR TITLE
Format floats with 2-decimal points

### DIFF
--- a/src/hf_mem/print.py
+++ b/src/hf_mem/print.py
@@ -3,7 +3,7 @@ import warnings
 from typing import Any, Dict, Literal, Optional
 
 MIN_NAME_LEN = 5
-MAX_NAME_LEN = 13
+MAX_NAME_LEN = 14
 MIN_DATA_LEN = 20
 MAX_DATA_LEN = 64
 BORDERS_AND_PADDING = 7
@@ -99,7 +99,7 @@ def _format_short_number(n: float) -> Optional[str]:
     n = float(n)
     for unit in ("", "K", "M", "B", "T"):
         if abs(n) < 1000.0:
-            return f"{int(n)}" if unit == "" else f"{n:.1f}{unit}"
+            return f"{int(n)}" if unit == "" else f"{n:.2f}{unit}"
         n /= 1000.0
 
 
@@ -183,7 +183,7 @@ def print_report_for_transformers(
         dtype_name = dtype.upper()
         dtype_gb = _bytes_to_gb(nbytes)
 
-        gb_text = f"{dtype_gb:.1f} / {total_gb:.1f} GB"
+        gb_text = f"{dtype_gb:.2f} / {total_gb:.2f} GB"
         _print_row(
             dtype_name + " " * (max_length - len(dtype_name)),
             gb_text,
@@ -292,7 +292,7 @@ def print_report_for_diffusers(
             dtype_name = dtype.upper()
             dtype_gb = _bytes_to_gb(nbytes)
 
-            gb_text = f"{dtype_gb:.1f} / {_bytes_to_gb(total_bytes):.1f} GB"
+            gb_text = f"{dtype_gb:.2f} / {_bytes_to_gb(total_bytes):.2f} GB"
             _print_row(
                 dtype_name + " " * (max_length - len(dtype_name)),
                 gb_text,


### PR DESCRIPTION
## Description

This PR formats the floats to use 2-decimal points instead of 1, given that in some cases 1 might be vague, and adding 2 doesn't hurt the visuals and is nice for transparency.

<table>
  <tr>
    <td style="text-align: center; vertical-align: top;">
      <h2>Before</h2>
      <img width="1212" height="421" alt="image" src="https://github.com/user-attachments/assets/1a957ac7-da91-4c2c-a689-ef3c4244c858" />
    </td>
    <td style="text-align: center; vertical-align: top;">
      <h2>After</h2>
      <img width="1222" height="423" alt="image" src="https://github.com/user-attachments/assets/293b08f9-a3a4-4005-983c-d3f0a5095303" />
    </td>
  </tr>
</table>