### PR TITLE
Add `--json-output` flag

### DIFF
--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -3,6 +3,7 @@ import asyncio
 import json
 import os
 import struct
+from dataclasses import asdict
 from functools import reduce
 from typing import Any, Dict, List, Optional
 
@@ -200,7 +201,7 @@ async def run(
 
     if json_output:
         out = {"model_id": model_id, "revision": revision}
-        out.update(metadata.to_dict())
+        out.update(asdict(metadata))
         print(json.dumps(out))
     else:
         print_report(

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -199,14 +199,16 @@ async def run(
         )
 
     if json_output:
-        return {"model_id": model_id, "revision": revision}.update(metadata.to_dict())
-
-    print_report(
-        model_id=model_id,
-        revision=revision,
-        metadata=metadata,
-        ignore_table_width=ignore_table_width,
-    )
+        out = {"model_id": model_id, "revision": revision}
+        out.update(metadata.to_dict())
+        print(json.dumps(out))
+    else:
+        print_report(
+            model_id=model_id,
+            revision=revision,
+            metadata=metadata,
+            ignore_table_width=ignore_table_width,
+        )
 
 
 def main() -> None:

--- a/src/hf_mem/metadata.py
+++ b/src/hf_mem/metadata.py
@@ -2,23 +2,27 @@ import math
 from dataclasses import dataclass
 from typing import Any, Dict
 
-from typing_extensions import Self
+from hf_mem.types import SafetensorsDtypes, get_safetensors_dtype_bytes
 
-from hf_mem.types import get_safetensors_dtype_bytes
+
+@dataclass
+class DtypeMetadata:
+    param_count: int
+    bytes_count: int
+
+
+@dataclass
+class ComponentMetadata:
+    dtypes: Dict[SafetensorsDtypes, DtypeMetadata]
+    param_count: int
+    bytes_count: int
 
 
 @dataclass
 class SafetensorsMetadata:
-    components: Dict[str, Any]
+    components: Dict[str, ComponentMetadata]
     param_count: int
     bytes_count: int
-
-    def to_dict(self: Self) -> Dict[str, Any]:
-        return {
-            "components": self.components,
-            "param_count": self.param_count,
-            "bytes_count": self.bytes_count,
-        }
 
 
 def parse_safetensors_metadata(raw_metadata: Dict[str, Any]) -> SafetensorsMetadata:
@@ -28,35 +32,35 @@ def parse_safetensors_metadata(raw_metadata: Dict[str, Any]) -> SafetensorsMetad
         raw_metadata = {"transformer": raw_metadata}
 
     components = {}
-    param_count, bytes_count = 0, 0
+    total_param_count, total_bytes_count = 0, 0
 
     for component_name, component_metadata in raw_metadata.items():
-        component = {"param_count": 0, "bytes_count": 0, "dtypes": {}}
+        component = ComponentMetadata(dtypes={}, param_count=0, bytes_count=0)
         for key, value in component_metadata.items():
             if key in {"__metadata__"}:
                 continue
 
             dtype = value["dtype"]
-            if dtype not in component["dtypes"]:
-                component["dtypes"][dtype] = {"param_count": 0, "bytes_count": 0}
+            if dtype not in component.dtypes:
+                component.dtypes[dtype] = DtypeMetadata(param_count=0, bytes_count=0)
 
             dtype_bytes = get_safetensors_dtype_bytes(dtype)
             current_shape = math.prod(value["shape"])
             current_shape_bytes = current_shape * dtype_bytes
 
-            component["dtypes"][dtype]["param_count"] += current_shape
-            component["param_count"] += current_shape
-            param_count += current_shape
+            component.dtypes[dtype].param_count += current_shape
+            component.param_count += current_shape
+            total_param_count += current_shape
 
-            component["dtypes"][dtype]["bytes_count"] += current_shape_bytes
-            component["bytes_count"] += current_shape
-            bytes_count += current_shape_bytes
+            component.dtypes[dtype].bytes_count += current_shape_bytes
+            component.bytes_count += current_shape
+            total_bytes_count += current_shape_bytes
 
         if component:
             components[component_name] = component
 
     return SafetensorsMetadata(
         components=components,
-        param_count=param_count,
-        bytes_count=bytes_count,
+        param_count=total_param_count,
+        bytes_count=total_bytes_count,
     )

--- a/src/hf_mem/metadata.py
+++ b/src/hf_mem/metadata.py
@@ -1,0 +1,62 @@
+import math
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from typing_extensions import Self
+
+from hf_mem.types import get_safetensors_dtype_bytes
+
+
+@dataclass
+class SafetensorsMetadata:
+    components: Dict[str, Any]
+    param_count: int
+    bytes_count: int
+
+    def to_dict(self: Self) -> Dict[str, Any]:
+        return {
+            "components": self.components,
+            "param_count": self.param_count,
+            "bytes_count": self.bytes_count,
+        }
+
+
+def parse_safetensors_metadata(raw_metadata: Dict[str, Any]) -> SafetensorsMetadata:
+    # NOTE: This is a small "hack" to prevent from having dedicated parsing functions for Transformers, Sentence
+    # Transformers and Diffusers, and rather unify within the same function
+    if "__metadata__" in raw_metadata:
+        raw_metadata = {"transformer": raw_metadata}
+
+    components = {}
+    param_count, bytes_count = 0, 0
+
+    for component_name, component_metadata in raw_metadata.items():
+        component = {"param_count": 0, "bytes_count": 0, "dtypes": {}}
+        for key, value in component_metadata.items():
+            if key in {"__metadata__"}:
+                continue
+
+            dtype = value["dtype"]
+            if dtype not in component["dtypes"]:
+                component["dtypes"][dtype] = {"param_count": 0, "bytes_count": 0}
+
+            dtype_bytes = get_safetensors_dtype_bytes(dtype)
+            current_shape = math.prod(value["shape"])
+            current_shape_bytes = current_shape * dtype_bytes
+
+            component["dtypes"][dtype]["param_count"] += current_shape
+            component["param_count"] += current_shape
+            param_count += current_shape
+
+            component["dtypes"][dtype]["bytes_count"] += current_shape_bytes
+            component["bytes_count"] += current_shape
+            bytes_count += current_shape_bytes
+
+        if component:
+            components[component_name] = component
+
+    return SafetensorsMetadata(
+        components=components,
+        param_count=param_count,
+        bytes_count=bytes_count,
+    )

--- a/src/hf_mem/print.py
+++ b/src/hf_mem/print.py
@@ -125,9 +125,9 @@ def print_report(
         if len(metadata.components) > 1:
             rows.append(name)
 
-        for dtype, dtype_metadata in nested_metadata["dtypes"].items():
+        for dtype, dtype_metadata in nested_metadata.dtypes.items():
             rows.append(
-                f"{dtype} {dtype_metadata['param_count']} {dtype_metadata['bytes_count']}"
+                f"{dtype} {dtype_metadata.param_count} {dtype_metadata.bytes_count}"
             )
 
     max_len = 0
@@ -156,7 +156,7 @@ def print_report(
         if len(metadata.components) > 1:
             _print_divider(current_len + 1, "top-continue")
             _print_centered(
-                f"{key.upper()} ({_bytes_to_gb(value['bytes_count']):.2f} GB)",
+                f"{key.upper()} ({_bytes_to_gb(value.bytes_count):.2f} GB)",
                 current_len,
             )
 
@@ -165,11 +165,11 @@ def print_report(
             _print_divider(current_len + 1)
 
         max_length = max([
-            len(f"{_format_short_number(dtype_metadata['param_count'])} PARAMS")
-            for _, dtype_metadata in value["dtypes"].items()
+            len(f"{_format_short_number(dtype_metadata.param_count)} PARAMS")
+            for _, dtype_metadata in value.dtypes.items()
         ])
-        for dtype, dtype_metadata in value["dtypes"].items():
-            gb_text = f"{_bytes_to_gb(dtype_metadata['bytes_count']):.2f} / {_bytes_to_gb(metadata.bytes_count):.2f} GB"
+        for dtype, dtype_metadata in value.dtypes.items():
+            gb_text = f"{_bytes_to_gb(dtype_metadata.bytes_count):.2f} / {_bytes_to_gb(metadata.bytes_count):.2f} GB"
             _print_row(
                 dtype.upper() + " " * (max_length - len(dtype)),
                 gb_text,
@@ -177,12 +177,12 @@ def print_report(
             )
 
             bar = _make_bar(
-                _bytes_to_gb(dtype_metadata["bytes_count"]),
+                _bytes_to_gb(dtype_metadata.bytes_count),
                 _bytes_to_gb(metadata.bytes_count),
                 current_len,
             )
             _print_row(
-                f"{_format_short_number(dtype_metadata['param_count'])} PARAMS",
+                f"{_format_short_number(dtype_metadata.param_count)} PARAMS",
                 bar,
                 current_len,
             )

--- a/src/hf_mem/print.py
+++ b/src/hf_mem/print.py
@@ -1,6 +1,5 @@
-import math
 import warnings
-from typing import Any, Dict, Literal, Optional
+from typing import Literal, Optional
 
 from hf_mem.metadata import SafetensorsMetadata
 

--- a/src/hf_mem/print.py
+++ b/src/hf_mem/print.py
@@ -96,12 +96,13 @@ def _make_bar(used: float, total: float, width: int) -> str:
     return "█" * filled + "░" * (width - filled)
 
 
-def _format_short_number(n: float) -> Optional[str]:
+def _format_short_number(n: float) -> str:
     n = float(n)
     for unit in ("", "K", "M", "B", "T"):
         if abs(n) < 1000.0:
             return f"{int(n)}" if unit == "" else f"{n:.2f}{unit}"
         n /= 1000.0
+    return f"{n:.2f}P"
 
 
 def _bytes_to_gb(nbytes: int) -> float:
@@ -130,9 +131,7 @@ def print_report(
                 f"{dtype} {dtype_metadata.param_count} {dtype_metadata.bytes_count}"
             )
 
-    max_len = 0
-    for r in rows:
-        max_len = max(max_len, len(str(r)))
+    max_len = max(len(str(r)) for r in rows)
 
     if max_len > MAX_DATA_LEN and ignore_table_width is False:
         warnings.warn(

--- a/src/hf_mem/types.py
+++ b/src/hf_mem/types.py
@@ -1,0 +1,32 @@
+from typing import Literal
+
+SafetensorsDtypes = Literal[
+    "F64",
+    "I64",
+    "U64",
+    "F32",
+    "I32",
+    "U32",
+    "F16",
+    "BF16",
+    "I16",
+    "U16",
+    "F8_E5M2",
+    "F8_E4M3",
+    "I8",
+    "U8",
+]
+
+
+def get_safetensors_dtype_bytes(dtype: str) -> int:
+    match dtype:
+        case "F64" | "I64" | "U64":
+            return 8
+        case "F32" | "I32" | "U32":
+            return 4
+        case "F16" | "BF16" | "I16" | "U16":
+            return 2
+        case "F8_E5M2" | "F8_E4M3" | "I8" | "U8":
+            return 1
+        case _:
+            raise RuntimeError(f"DTYPE={dtype} NOT HANDLED")


### PR DESCRIPTION
## Description

This PR adds the `--json-output` flag as requested by multiple users, with a tentative format for the output, in a similar fashion as shown in the table, which remains the default output format.

This PR adds the `parse_safetensors_metadata` to read the raw metadata into `SafetensorsMetadata` dataclass, as well as unifying the printing function under `print_report` which prints Transformers, Sentence Transformers and Diffusers metadata within the same snippet.