### PR TITLE
fix: detect tensor-level metadata without relying on __metadata__ key

### DIFF
--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -102,7 +102,9 @@ async def run(
 
         # NOTE: If the model is a transformers model, then we simply set the component name to `Transformer`, to
         # make sure that we provide the expected input to the `parse_safetensors_metadata`
-        if "__metadata__" in raw_metadata:
+        # Check if raw_metadata is tensor-level (has dtype/shape) rather than component-level
+        first_value = next((v for k, v in raw_metadata.items() if k != "__metadata__"), None)
+        if first_value and isinstance(first_value, dict) and "dtype" in first_value:
             raw_metadata = {"Transformer": raw_metadata}
 
         metadata = parse_safetensors_metadata(raw_metadata=raw_metadata)
@@ -135,7 +137,9 @@ async def run(
 
         # NOTE: If the model is a transformers model, then we simply set the component name to `Transformer`, to
         # make sure that we provide the expected input to the `parse_safetensors_metadata`
-        if "__metadata__" in raw_metadata:
+        # Check if raw_metadata is tensor-level (has dtype/shape) rather than component-level
+        first_value = next((v for k, v in raw_metadata.items() if k != "__metadata__"), None)
+        if first_value and isinstance(first_value, dict) and "dtype" in first_value:
             raw_metadata = {"Transformer": raw_metadata}
 
         metadata = parse_safetensors_metadata(raw_metadata=raw_metadata)


### PR DESCRIPTION
## Problem

Some models do not include the optional `__metadata__` key in their safetensors files.
The previous logic used `__metadata__` presence to detect whether raw_metadata needed to be wrapped as a Transformer component.

### Error before fix

```
Traceback (most recent call last):
  File ".../hf_mem/cli.py", line 141, in run
    metadata = parse_safetensors_metadata(raw_metadata=raw_metadata)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../hf_mem/metadata.py", line 40, in parse_safetensors_metadata
    dtype = value["dtype"]
            ~~~~~^^^^^^^^^
TypeError: string indices must be integers, not 'str'
```
<img width="1667" height="1079" alt="Screenshot from 2026-01-07 14-02-23" src="https://github.com/user-attachments/assets/557d3195-8e99-473d-96a6-4be836578a48" />


### Affected models (examples)
- `openai/gpt-oss-120b`
- `skt/A.X-K1`
- `zai-org/GLM-4.7`

## Solution

Check if the first non-metadata entry has `dtype` key instead, which reliably indicates tensor-level metadata regardless of whether `__metadata__` exists.

## Test

- [x] `uv run hf-mem --model-id openai/gpt-oss-120b`
- [x] `uv run hf-mem --model-id skt/A.X-K1`