### PR TITLE
Fix default component and add missing table divider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hf-mem"
-version = "0.2.1"
+version = "0.2.2"
 description = "A CLI to estimate inference memory requirements for Hugging Face models, written in Python"
 readme = "README.md"
 authors = [

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -99,10 +99,9 @@ async def run(
         # set the default component name to `0_Transformer` as defined in modules.json
         if "config_sentence_transformers.json" in file_paths:
             raw_metadata = {"0_Transformer": raw_metadata}
-
-        # NOTE: If the model is a transformers model, then we simply set the component name to `Transformer`, to
-        # make sure that we provide the expected input to the `parse_safetensors_metadata`
-        if "__metadata__" in raw_metadata:
+        else:
+            # NOTE: If the model is a transformers model, then we simply set the component name to `Transformer`, to
+            # make sure that we provide the expected input to the `parse_safetensors_metadata`
             raw_metadata = {"Transformer": raw_metadata}
 
         metadata = parse_safetensors_metadata(raw_metadata=raw_metadata)
@@ -132,10 +131,9 @@ async def run(
         # set the default component name to `0_Transformer` as defined in modules.json
         if "config_sentence_transformers.json" in file_paths:
             raw_metadata = {"0_Transformer": raw_metadata}
-
-        # NOTE: If the model is a transformers model, then we simply set the component name to `Transformer`, to
-        # make sure that we provide the expected input to the `parse_safetensors_metadata`
-        if "__metadata__" in raw_metadata:
+        else:
+            # NOTE: If the model is a transformers model, then we simply set the component name to `Transformer`, to
+            # make sure that we provide the expected input to the `parse_safetensors_metadata`
             raw_metadata = {"Transformer": raw_metadata}
 
         metadata = parse_safetensors_metadata(raw_metadata=raw_metadata)

--- a/src/hf_mem/print.py
+++ b/src/hf_mem/print.py
@@ -163,10 +163,12 @@ def print_report(
         else:
             _print_divider(current_len + 1)
 
-        max_length = max([
-            len(f"{_format_short_number(dtype_metadata.param_count)} PARAMS")
-            for _, dtype_metadata in value.dtypes.items()
-        ])
+        max_length = max(
+            [
+                len(f"{_format_short_number(dtype_metadata.param_count)} PARAMS")
+                for _, dtype_metadata in value.dtypes.items()
+            ]
+        )
         for idx, (dtype, dtype_metadata) in enumerate(value.dtypes.items()):
             gb_text = (
                 f"{_bytes_to_gb(dtype_metadata.bytes_count):.2f} / {_bytes_to_gb(metadata.bytes_count):.2f} GB"

--- a/src/hf_mem/print.py
+++ b/src/hf_mem/print.py
@@ -163,13 +163,11 @@ def print_report(
         else:
             _print_divider(current_len + 1)
 
-        max_length = max(
-            [
-                len(f"{_format_short_number(dtype_metadata.param_count)} PARAMS")
-                for _, dtype_metadata in value.dtypes.items()
-            ]
-        )
-        for dtype, dtype_metadata in value.dtypes.items():
+        max_length = max([
+            len(f"{_format_short_number(dtype_metadata.param_count)} PARAMS")
+            for _, dtype_metadata in value.dtypes.items()
+        ])
+        for idx, (dtype, dtype_metadata) in enumerate(value.dtypes.items()):
             gb_text = (
                 f"{_bytes_to_gb(dtype_metadata.bytes_count):.2f} / {_bytes_to_gb(metadata.bytes_count):.2f} GB"
             )
@@ -189,5 +187,8 @@ def print_report(
                 bar,
                 current_len,
             )
+
+            if idx < len(value.dtypes) - 1:
+                _print_divider(current_len + 1)
 
     _print_divider(current_len + 1, "bottom")

--- a/uv.lock
+++ b/uv.lock
@@ -88,7 +88,7 @@ wheels = [
 
 [[package]]
 name = "hf-mem"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", extra = ["http2"] },


### PR DESCRIPTION
## Description

This PR fixes a bug with the default component name for models that were neither Diffusers nor Transformers, as the `__metadata__` might be optional, hence some models were failing to properly format the `raw_metadata` dict prior calling `parse_safetensors_metadata`.

This PR also fixes the table output for models with multiple co-existing dtypes, as a divider was missing in between the dtypes.

Finally, this PR also sets the `version` to 0.2.2, to release right after merging given that this PR comes with bug fixes.