### PR TITLE
Set `version` to 0.3.0 (before release)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hf-mem"
-version = "0.2.2"
+version = "0.3.0"
 description = "A CLI to estimate inference memory requirements for Hugging Face models, written in Python"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -88,7 +88,7 @@ wheels = [
 
 [[package]]
 name = "hf-mem"
-version = "0.2.2"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", extra = ["http2"] },


### PR DESCRIPTION
## Description

This PR runs `uv version 0.3.0` to set the `hf-mem` version in both `pyproject.toml` and `uv.lock` to 0.3.0 before the upcoming release.