### PR TITLE
Set custom "User-Agent" in request headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ---
 
-`hf-mem` is an experimental CLI to estimate inference memory requirements for Hugging Face models, written in Python. `hf-mem` is lightweight, only depends on `httpx`. It's recommended to run with [`uv`](https://github.com/astral-sh/uv) for a better experience.
+`hf-mem` is an experimental CLI to estimate inference memory requirements for Hugging Face models, written in Python. `hf-mem` is lightweight, only depends on `httpx`, as it pulls the Safetensors metadata via HTTP Range requests. It's recommended to run with [`uv`](https://github.com/astral-sh/uv) for a better experience.
 
 `hf-mem` lets you estimate the inference requirements to run any model from the Hugging Face Hub, including Transformers, Diffusers and Sentence Transformers models, as well as any model that contains [Safetensors](https://github.com/huggingface/safetensors) compatible weights.
 

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -6,6 +6,7 @@ import struct
 from dataclasses import asdict
 from functools import reduce
 from typing import Any, Dict, List, Optional
+from uuid import uuid4
 
 import httpx
 
@@ -82,7 +83,7 @@ async def run(
     json_output: bool = False,
     ignore_table_width: bool = False,
 ) -> Dict[str, Any] | None:
-    headers = {"User-Agent": f"hf-mem/0.3; model_id={model_id}; revision={revision}"}
+    headers = {"User-Agent": f"hf-mem/0.3; id={uuid4()}; model_id={model_id}; revision={revision}"}
     # NOTE: Read from `HF_TOKEN` if provided, then fallback to reading from `$HF_HOME/token`
     if token := os.getenv("HF_TOKEN"):
         headers["Authorization"] = f"Bearer {token}"

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -82,7 +82,7 @@ async def run(
     json_output: bool = False,
     ignore_table_width: bool = False,
 ) -> Dict[str, Any] | None:
-    headers = {}
+    headers = {"User-Agent": f"hf-mem/0.3; model_id={model_id}; revision={revision}"}
     # NOTE: Read from `HF_TOKEN` if provided, then fallback to reading from `$HF_HOME/token`
     if token := os.getenv("HF_TOKEN"):
         headers["Authorization"] = f"Bearer {token}"

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -104,6 +104,7 @@ async def run(
             max_connections=MAX_CONCURRENCY,
         ),
         timeout=httpx.Timeout(REQUEST_TIMEOUT),
+        # NOTE: HTTP/2 for header-compression and connection multiplexing
         http2=True,
         follow_redirects=True,
     )


### PR DESCRIPTION
## Description

This PR adds the `"User-Agent": "hf-mem/<version>; id=<id>; model_id=<model_id>; revision=<revision>"` header to the requests, so as to better monitor the requests that are being sent from `hf-mem`.