### PR TITLE
Add `--kv-cache-dtype` argument

### DIFF
--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -293,7 +293,7 @@ async def run(
                 if batch_size:
                     cache_size *= batch_size
 
-                if kv_cache_dtype in {"fp8_e5m2", "fp8_e4m3"}:
+                if kv_cache_dtype in {"bfloat16", "fp8_e5m2", "fp8_e4m3"}:
                     cache_dtype = kv_cache_dtype.upper()
                 elif kv_cache_dtype in {"fp8", "fp8_ds_mla", "fp8_inc"}:
                     # NOTE: Default to `FP8` for the calculations, given that all those take 1 byte, but only FP8

--- a/src/hf_mem/types.py
+++ b/src/hf_mem/types.py
@@ -11,8 +11,8 @@ SafetensorsDtypes = Literal[
     "BF16",
     "I16",
     "U16",
-    "F8_E5M2",
-    "F8_E4M3",
+    "F8_E5M2",  # NOTE: Only CUDA +11.8
+    "F8_E4M3",  # NOTE: CUDA +11.8 and AMD ROCm
     "I8",
     "U8",
 ]

--- a/src/hf_mem/types.py
+++ b/src/hf_mem/types.py
@@ -32,7 +32,7 @@ def get_safetensors_dtype_bytes(dtype: SafetensorsDtypes | str) -> int:
             raise RuntimeError(f"DTYPE={dtype} NOT HANDLED")
 
 
-TorchDtypes = Literal["float32", "float16", "bfloat16", "float8_e4m3fn", "float8_e5m2", "int8"]
+TorchDtypes = Literal["float32", "float16", "bfloat16", "float8_e4m3", "float8_e4m3fn", "float8_e5m2", "int8"]
 
 
 def torch_dtype_to_safetensors_dtype(dtype: TorchDtypes | str) -> SafetensorsDtypes:
@@ -45,7 +45,7 @@ def torch_dtype_to_safetensors_dtype(dtype: TorchDtypes | str) -> SafetensorsDty
             return "F16"
         case "bfloat16":
             return "BF16"
-        case "float8_e4m3fn":
+        case "float8_e4m3fn" | "float8_e4m3fn":
             return "F8_E4M3"
         case "float8_e5m2":
             return "F8_E5M2"


### PR DESCRIPTION
## Description

This PR adds the `--kv-cache-dtype` argument as in vLLM as per https://docs.vllm.ai/en/stable/cli/serve/#-kv-cache-dtype, so that instead of defaulting to the `dtype` that's set in `config.json` under the keys `torch_dtype` or `dtype` in that order of priority, it's manually specified.

---

- [x] I have read and followed the guidelines in [`CONTRIBUTING.md`](/CONTRIBUTING.md).
- [ ] This has been discussed over an issue or discussion.