### PR TITLE
Use `quantization_config` from `config.json` when `--kv-cache-dtype auto`

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ uvx hf-mem --model-id google/embeddinggemma-300m
 By enabling the `--experimental` flag, you can enable the KV Cache memory estimation for LLMs (`...ForCausalLM`) and VLMs (`...ForConditionalGeneration`), even including a custom `--max-model-len` (defaults to the `config.json` default), `--batch-size` (defaults to 1), and the `--kv-cache-dtype` (defaults to `auto` which means it uses the default data type set in `config.json`).
 
 ```bash
-uvx hf-mem --model-id MiniMaxAI/MiniMax-M2 --experimental --max-model-len 65536 --batch-size 1 --kv-cache-dtype fp8_e4m3
+uvx hf-mem --model-id MiniMaxAI/MiniMax-M2 --experimental
 ```
 
 <img src="https://github.com/user-attachments/assets/247113cf-59a7-4f76-a8df-735e292558a0" />

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -320,7 +320,7 @@ async def run(
                     cache_dtype = torch_dtype_to_safetensors_dtype(_fmt)
                 else:
                     raise RuntimeError(
-                        f"Provided `--kv-cache-dtype={kv_cache_dtype}` but it needs to be any of `auto`, `fp8`, `fp8_e5m2` or `fp8_e4m3`, and if `auto` is provided then `config.json` needs to contain either `torch_dtype` or `dtype` set."
+                        f"Provided `--kv-cache-dtype={kv_cache_dtype}` but it needs to be any of `auto`, `bfloat16`, `fp8`, `fp8_ds_mla`, `fp8_e4m3`, `fp8_e5m2` or `fp8_inc`. If `auto` is set, then the `config.json` should either contain the `torch_dtype` or `dtype` fields set, or if quantized then `quantization_config` needs to be set and contain the keys `quant_method` and `fmt`, with `quant_method` being `fp8` and `fmt` any valid format as per the `fp8` formats mentioned before."
                     )
 
     if json_output:


### PR DESCRIPTION
## Description

This PR leverages the `quantization_config` in the `config.json` file when available, to provide a sensible default for the `--kv-cache-dtype` argument when applicable.

- [x] I have read and followed the guidelines in [`CONTRIBUTING.md`](/CONTRIBUTING.md).
- [ ] This has been discussed over an issue or discussion.

cc @alvarobartt