### PR TITLE
fix: correct capitalization for safetensors dtypes

### DIFF
--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -274,7 +274,7 @@ async def run(
                     )
 
                 if kv_cache_dtype in {"fp8_e5m2", "fp8_e4m3"}:
-                    cache_dtype = kv_cache_dtype.upper()
+                    cache_dtype = "F8_" + kv_cache_dtype[3:].upper()
                 elif kv_cache_dtype in {"fp8", "fp8_ds_mla", "fp8_inc"}:
                     # NOTE: Default to `FP8` for the calculations, given that all those take 1 byte, but only FP8
                     # is supported in Safetensors, whilst FP8_DS_MLA (DeepSeek MLA) and FP8_INC (Intel HPUs) are not

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -274,7 +274,7 @@ async def run(
                     )
 
                 if kv_cache_dtype in {"fp8_e5m2", "fp8_e4m3"}:
-                    cache_dtype = "F8_" + kv_cache_dtype[4:].upper()
+                    cache_dtype = kv_cache_dtype.upper().replace("FP8", "F8")
                 elif kv_cache_dtype in {"fp8", "fp8_ds_mla", "fp8_inc"}:
                     # NOTE: Default to `FP8` for the calculations, given that all those take 1 byte, but only FP8
                     # is supported in Safetensors, whilst FP8_DS_MLA (DeepSeek MLA) and FP8_INC (Intel HPUs) are not

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -274,7 +274,7 @@ async def run(
                     )
 
                 if kv_cache_dtype in {"fp8_e5m2", "fp8_e4m3"}:
-                    cache_dtype = "F8_" + kv_cache_dtype[3:].upper()
+                    cache_dtype = "F8_" + kv_cache_dtype[4:].upper()
                 elif kv_cache_dtype in {"fp8", "fp8_ds_mla", "fp8_inc"}:
                     # NOTE: Default to `FP8` for the calculations, given that all those take 1 byte, but only FP8
                     # is supported in Safetensors, whilst FP8_DS_MLA (DeepSeek MLA) and FP8_INC (Intel HPUs) are not


### PR DESCRIPTION
## Description

When converting `fp8_e4m3` or `fp8_e5m2` to safetensors dtype format, the code used `.upper()` which produced `FP8_E4M3`/`FP8_E5M2` (with P), but the expected format was `F8_E4M3`/`F8_E5M2` (without P), as specified in `types.py`

This causes RuntimeError if we pass fp8_e4m3 as the kvcache dtype in `cli.py::run()`

---

- [x] I have read and followed the guidelines in [`CONTRIBUTING.md`](/CONTRIBUTING.md).
- [ ] This has been discussed over an issue or discussion.
