### PR TITLE
Add support for GGUF files + KV cache from GGUF metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ Optionally, you can add `hf-mem` as an agent skill, which allows the underlying 
 
 More information can be found at [Anthropic Agent Skills and how to use them](https://github.com/anthropics/skills).
 
+
+## GGUF Files
+
+By enabling the `--gguf` flag, you can estimate memory requirements for *.gguf* files. All files will be listed with their corresponding memory estimations. For a more in depth report like the one used for *.safetensors* files (with information regarding weight dtypes) the flag `--gguf-file` can be used to estimate a single GGUF model. For sharded files, the path to any of the individual shards will work.
+
+```bash
+uvx hf-mem --model-id TheBloke/deepseek-llm-7B-chat-GGUF --gguf
+```
+
+(here image of the listed results)
+
 ## References
 
 - [Safetensors Metadata parsing](https://huggingface.co/docs/safetensors/en/metadata_parsing)

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ More information can be found at [Anthropic Agent Skills and how to use them](ht
 
 ## GGUF Files
 
-By enabling the `--gguf` flag, you can estimate memory requirements for *.gguf* files. All files will be listed with their corresponding memory estimations. For a more in depth report like the one used for *.safetensors* files (with information regarding weight dtypes) the flag `--gguf-file` can be used to estimate a single GGUF model. For sharded files, the path to any of the individual shards will work.
+*.gguf* files will only be listed when no other *.safetensors* files are present in the repository or when using the `--gguf-file` flag followed by a filepath to a GGUF model. For sharded files, the path to any of the individual shards will work.
 
 ```bash
-uvx hf-mem --model-id TheBloke/deepseek-llm-7B-chat-GGUF --gguf
+uvx hf-mem --model-id TheBloke/deepseek-llm-7B-chat-GGUF --gguf-file deepseek-llm-7b-chat.Q2_K.gguf
 ```
 
 (here image of the listed results)

--- a/README.md
+++ b/README.md
@@ -47,22 +47,21 @@ uvx hf-mem --model-id MiniMaxAI/MiniMax-M2 --experimental
 
 <img src="https://github.com/user-attachments/assets/64eaff88-d395-4d8d-849b-78fb86411dc3" />
 
+## GGUF Files
+
+*.gguf* files will only be listed when no other *.safetensors* files are present in the repository or when using the `--gguf-file` flag followed by a filepath to a GGUF model. For sharded files, the path to any of the individual shards will work. Other flags like `--experimental` or the ones regarding KV cache calculations are also compatible.
+
+```bash
+uvx hf-mem --model-id TheBloke/deepseek-llm-7B-chat-GGUF --gguf-file deepseek-llm-7b-chat.Q2_K.gguf --experimental
+```
+
+<img width="1140" height="1065" alt="image" src="https://github.com/user-attachments/assets/9cdcb769-6ca9-4ed9-adaf-630848c94356" />
+
 ## (Optional) Agent Skills
 
 Optionally, you can add `hf-mem` as an agent skill, which allows the underlying coding agent to discover and use it when provided as a [`SKILL.md`](.skills/hf-mem/SKILL.md).
 
 More information can be found at [Anthropic Agent Skills and how to use them](https://github.com/anthropics/skills).
-
-
-## GGUF Files
-
-*.gguf* files will only be listed when no other *.safetensors* files are present in the repository or when using the `--gguf-file` flag followed by a filepath to a GGUF model. For sharded files, the path to any of the individual shards will work.
-
-```bash
-uvx hf-mem --model-id TheBloke/deepseek-llm-7B-chat-GGUF --gguf-file deepseek-llm-7b-chat.Q2_K.gguf
-```
-
-(here image of the listed results)
 
 ## References
 

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -2,6 +2,7 @@ import argparse
 import asyncio
 import json
 import os
+import re
 import struct
 import warnings
 from dataclasses import asdict
@@ -15,6 +16,7 @@ from hf_mem import __version__
 from hf_mem.metadata import parse_safetensors_metadata
 from hf_mem.print import print_report, print_report_for_gguf
 from hf_mem.types import TorchDtypes, get_safetensors_dtype_bytes, torch_dtype_to_safetensors_dtype
+from hf_mem.gguf import fetch_gguf_metadata, gguf_metadata_to_json, GGUFMetadata, merge_shards
 
 # NOTE: Defines the bytes that will be fetched per safetensors file, but the metadata
 # can indeed be larger than that
@@ -91,6 +93,7 @@ async def run(
     # END_KV_CACHE_ARGS
     json_output: bool = False,
     ignore_table_width: bool = False,
+    gguf: bool = False,
 ) -> Dict[str, Any] | None:
     headers = {"User-Agent": f"hf-mem/0.4; id={uuid4()}; model_id={model_id}; revision={revision}"}
     # NOTE: Read from `HF_TOKEN` if provided, then fallback to reading from `$HF_HOME/token`
@@ -125,7 +128,58 @@ async def run(
     files = await get_json_file(client=client, url=url, headers=headers)
     file_paths = [f["path"] for f in files if f.get("path") and f.get("type") == "file"]
 
-    if "model.safetensors" in file_paths:
+    # GGUF support
+    if gguf:
+        gguf_paths = [f for f in file_paths if str(f).endswith(".gguf")]
+        if not gguf_paths:
+            raise RuntimeError(f"No GGUF files found for {model_id} @ {revision}.")
+        
+        gguf_files: Dict[str, GGUFMetadata] = dict()
+        for path in gguf_paths:
+            f_url = f"https://huggingface.co/{model_id}/resolve/{revision}/{str(path)}"
+            metadata = await fetch_gguf_metadata(
+                client=client, 
+                url=f_url, 
+                experimental=experimental,
+                max_model_len=max_model_len,
+                kv_cache_dtype=kv_cache_dtype,
+                batch_size=batch_size,
+            )
+
+            # In sharded GGUF files tensor metadata also gets sharded, so we need to merge them all
+            shard_pattern = re.match(r'(.+)-\d+-of-\d+\.gguf$', str(path)) # Ex: Kimi-K2.5-BF16-00001-of-00046.gguf
+            if shard_pattern:
+                # Ex: base_name = Kimi-K2.5-BF16
+                base_name = shard_pattern.group(1) + ".gguf"
+                print(base_name)
+                if base_name in gguf_files:
+                    gguf_files[base_name] = merge_shards(gguf_files[base_name], metadata)
+                else:
+                    gguf_files[base_name] = metadata
+            else:
+                gguf_files[str(path)] = metadata 
+        
+        
+        if json_output:
+            print(
+                json.dumps([
+                    gguf_metadata_to_json(
+                        model_id=model_id, 
+                        revision=revision, 
+                        metadata=gguf_metadata
+                    ) 
+                    for gguf_metadata in gguf_files.values()
+                ])
+            )
+        else:
+            print_report_for_gguf(
+                model_id=model_id,
+                revision=revision,
+                gguf_files=gguf_files,
+                ignore_table_width=ignore_table_width
+            )
+        return
+    elif "model.safetensors" in file_paths:
         url = f"https://huggingface.co/{model_id}/resolve/{revision}/model.safetensors"
         raw_metadata = await fetch_safetensors_metadata(client=client, url=url, headers=headers)
 
@@ -236,25 +290,9 @@ async def run(
 
         metadata = parse_safetensors_metadata(raw_metadata=raw_metadata)
     else:
-        # Check for GGUF files
-        gguf_files = {
-            f["path"]: f["size"]
-            for f in files
-            if f.get("path", "").endswith(".gguf") and f.get("size") is not None
-        }
-
-        if gguf_files:
-            print_report_for_gguf(
-                model_id=model_id,
-                revision=revision,
-                gguf_files=gguf_files,
-                ignore_table_width=ignore_table_width,
-            )
-            return
-        else:
-            raise RuntimeError(
-                "NONE OF `model.safetensors`, `model.safetensors.index.json`, `model_index.json`, OR `.gguf` FILES HAVE BEEN FOUND"
-            )
+        raise RuntimeError(
+            "NONE OF `model.safetensors`, `model.safetensors.index.json`, `model_index.json` FILES HAVE BEEN FOUND"
+        )
 
     cache_size = None
     if experimental:
@@ -462,7 +500,11 @@ def main() -> None:
         action="store_true",
         help="Whether to ignore the maximum recommended table width, in case the `--model-id` and/or `--revision` cause a row overflow when printing those.",
     )
-
+    parser.add_argument(
+        "--gguf",
+        action="store_true",
+        help="Whether to parse GGUF files instead of Safetensors ones.",
+    )
     args = parser.parse_args()
 
     if args.experimental:
@@ -482,5 +524,7 @@ def main() -> None:
             # NOTE: Below are the arguments that affect the output format
             json_output=args.json_output,
             ignore_table_width=args.ignore_table_width,
+            # GGUF flag
+            gguf=args.gguf,
         )
     )

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -13,10 +13,10 @@ from uuid import uuid4
 import httpx
 
 from hf_mem import __version__
+from hf_mem.gguf import GGUFDtype, GGUFMetadata, fetch_gguf_with_semaphore, gguf_metadata_to_json, merge_shards
 from hf_mem.metadata import parse_safetensors_metadata
 from hf_mem.print import print_report, print_report_for_gguf
 from hf_mem.types import TorchDtypes, get_safetensors_dtype_bytes, torch_dtype_to_safetensors_dtype
-from hf_mem.gguf import fetch_gguf_with_semaphore, gguf_metadata_to_json, merge_shards, GGUFMetadata, GGUFDtype
 
 # NOTE: Defines the bytes that will be fetched per safetensors file, but the metadata
 # can indeed be larger than that
@@ -126,15 +126,16 @@ async def run(
     url = f"https://huggingface.co/api/models/{model_id}/tree/{revision}?recursive=true"
     files = await get_json_file(client=client, url=url, headers=headers)
     file_paths = [f["path"] for f in files if f.get("path") and f.get("type") == "file"]
-    
 
     # NOTE: GGUF support only applies if:
     # 1. The `--gguf-file` flag is set.
     # 2. No Safetensors files are found and at least one gguf file is found
     gguf_paths = [f for f in file_paths if str(f).endswith(".gguf")]
-    has_safetensors = any(f in ["model.safetensors", "model.safetensors.index.json", "model_index.json"] for f in file_paths)
+    has_safetensors = any(
+        f in ["model.safetensors", "model.safetensors.index.json", "model_index.json"] for f in file_paths
+    )
     gguf = gguf_file is not None or (gguf_paths and not has_safetensors)
-    
+
     if not gguf and (has_safetensors and gguf_paths):
         warnings.warn(
             f"Both Safetensors and GGUF files have been found for {model_id} @ {revision}, if you want to estimate any of the GGUF file sizes, please use the `--gguf-file` flag with the path to the specific GGUF file. GGUF files found: {gguf_paths}."
@@ -142,23 +143,31 @@ async def run(
 
     if gguf:
         if kv_cache_dtype not in GGUFDtype.__members__ and kv_cache_dtype != "auto":
-            raise RuntimeError(f"--kv-cache-dtype={kv_cache_dtype} not recognized for GGUF files. Valid options: {list(GGUFDtype.__members__.keys())} or `auto`.")
-        
+            raise RuntimeError(
+                f"--kv-cache-dtype={kv_cache_dtype} not recognized for GGUF files. Valid options: {list(GGUFDtype.__members__.keys())} or `auto`."
+            )
+
         if not gguf_paths:
             raise RuntimeError(f"No GGUF files found for {model_id} @ {revision}.")
-        
+
         if gguf_file:
             # Check if it's a sharded file (model-00001-of-00046.gguf)
-            if prefix_match := re.match(r'(.+)-\d+-of-\d+\.gguf$', gguf_file):
+            if prefix_match := re.match(r"(.+)-\d+-of-\d+\.gguf$", gguf_file):
                 # Keep all shards with the same prefix
                 prefix = prefix_match.group(1)
-                gguf_paths = [path for path in gguf_paths if re.match(rf'{re.escape(prefix)}-\d+-of-\d+\.gguf$', str(path))]
+                gguf_paths = [
+                    path
+                    for path in gguf_paths
+                    if re.match(rf"{re.escape(prefix)}-\d+-of-\d+\.gguf$", str(path))
+                ]
             else:
                 # Not sharded
                 gguf_paths = [path for path in gguf_paths if str(path).endswith(gguf_file)]
                 if len(gguf_paths) > 1:
-                    raise RuntimeError(f"Multiple GGUF files named `{gguf_file}` found for {model_id} @ {revision}.")
-            
+                    raise RuntimeError(
+                        f"Multiple GGUF files named `{gguf_file}` found for {model_id} @ {revision}."
+                    )
+
             if not gguf_paths:
                 raise RuntimeError(f"No GGUF file matching `{gguf_file}` found for {model_id} @ {revision}.")
 
@@ -167,13 +176,15 @@ async def run(
         tasks = []
         for path in gguf_paths:
             # In sharded GGUF files tensor metadata also gets sharded, so we need to merge them all
-            shard_pattern = re.match(r'(.+)-(\d+)-of-(\d+)\.gguf$', str(path)) # Ex: Kimi-K2.5-BF16-00001-of-00046.gguf
+            shard_pattern = re.match(
+                r"(.+)-(\d+)-of-(\d+)\.gguf$", str(path)
+            )  # Ex: Kimi-K2.5-BF16-00001-of-00046.gguf
             parse_kv_cache = experimental
             # For sharded files, parsing kv_cache data might result in runtime errors (missing fields)
             if experimental and shard_pattern:
-                shard_num = int(shard_pattern.group(2)) # Get first number
-                parse_kv_cache = (shard_num == 1)
-            
+                shard_num = int(shard_pattern.group(2))  # Get first number
+                parse_kv_cache = shard_num == 1
+
             task = asyncio.create_task(
                 fetch_gguf_with_semaphore(
                     semaphore=semaphore,
@@ -204,19 +215,16 @@ async def run(
                 else:
                     gguf_files[base_name] = metadata
             else:
-                gguf_files[path] = metadata 
-        
-        
+                gguf_files[path] = metadata
+
         if json_output:
             print(
-                json.dumps([
-                    gguf_metadata_to_json(
-                        model_id=filename, 
-                        revision=revision, 
-                        metadata=gguf_metadata
-                    ) 
-                    for filename, gguf_metadata in gguf_files.items()
-                ])
+                json.dumps(
+                    [
+                        gguf_metadata_to_json(model_id=filename, revision=revision, metadata=gguf_metadata)
+                        for filename, gguf_metadata in gguf_files.items()
+                    ]
+                )
             )
         else:
             if gguf_file:
@@ -247,11 +255,11 @@ async def run(
             else:
                 # For multiple files, we use the new one
                 print_report_for_gguf(
-                model_id=model_id,
-                revision=revision,
-                gguf_files=gguf_files,
-                ignore_table_width=ignore_table_width
-            )
+                    model_id=model_id,
+                    revision=revision,
+                    gguf_files=gguf_files,
+                    ignore_table_width=ignore_table_width,
+                )
         return
     elif "model.safetensors" in file_paths:
         url = f"https://huggingface.co/{model_id}/resolve/{revision}/model.safetensors"
@@ -585,9 +593,11 @@ def main() -> None:
         warnings.warn(
             "`--experimental` is set, which means that models with an architecture as `...ForCausalLM` and `...ForConditionalGeneration` will include estimations for the KV Cache as well. You can also provide the args `--max-model-len` and `--batch-size` as part of the estimation. Note that enabling `--experimental` means that the output will be different both when displayed and when dumped as JSON with `--json-output`, so bear that in mind."
         )
-    
+
     if args.kv_cache_dtype not in KV_CACHE_DTYPE_CHOICES:
-        raise RuntimeError(f"--kv-cache-dtype={args.kv_cache_dtype} not recognized. Valid options: {KV_CACHE_DTYPE_CHOICES}.")
+        raise RuntimeError(
+            f"--kv-cache-dtype={args.kv_cache_dtype} not recognized. Valid options: {KV_CACHE_DTYPE_CHOICES}."
+        )
 
     asyncio.run(
         run(
@@ -602,6 +612,6 @@ def main() -> None:
             json_output=args.json_output,
             ignore_table_width=args.ignore_table_width,
             # NOTE: GGUF flags
-            gguf_file=args.gguf_file
+            gguf_file=args.gguf_file,
         )
     )

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -140,7 +140,7 @@ async def run(
         for path in gguf_paths:
             # In sharded GGUF files tensor metadata also gets sharded, so we need to merge them all
             shard_pattern = re.match(r'(.+)-(\d+)-of-(\d+)\.gguf$', str(path)) # Ex: Kimi-K2.5-BF16-00001-of-00046.gguf
-            parse_kv_cache = True
+            parse_kv_cache = experimental
             # For sharded files, parsing kv_cache data might result in runtime errors (missing fields)
             if shard_pattern:
                 shard_num = int(shard_pattern.group(2)) # Get first number

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -122,10 +122,6 @@ async def run(
         follow_redirects=True,
     )
 
-    # TODO: `recursive=true` shouldn't really be required unless it's a Diffusers
-    # models... I don't think this adds extra latency anyway
-    # NOTE: `recursive=true` is also need for GGUF file directories where each 
-    # sharded quantization is inside a different folder like: Q2_K/model_Q2_K-0001-of-0048.gguf
     url = f"https://huggingface.co/api/models/{model_id}/tree/{revision}?recursive=true"
     files = await get_json_file(client=client, url=url, headers=headers)
     file_paths = [f["path"] for f in files if f.get("path") and f.get("type") == "file"]
@@ -142,7 +138,7 @@ async def run(
             shard_pattern = re.match(r'(.+)-(\d+)-of-(\d+)\.gguf$', str(path)) # Ex: Kimi-K2.5-BF16-00001-of-00046.gguf
             parse_kv_cache = experimental
             # For sharded files, parsing kv_cache data might result in runtime errors (missing fields)
-            if shard_pattern:
+            if experimental and shard_pattern:
                 shard_num = int(shard_pattern.group(2)) # Get first number
                 parse_kv_cache = (shard_num == 1)
 

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -126,23 +126,24 @@ async def run(
     url = f"https://huggingface.co/api/models/{model_id}/tree/{revision}?recursive=true"
     files = await get_json_file(client=client, url=url, headers=headers)
     file_paths = [f["path"] for f in files if f.get("path") and f.get("type") == "file"]
-
-    has_safetensors = any(f in ["model.safetensors", "model.safetensors.index.json", "model_index.json"] for f in file_paths)
-    has_gguf = any([f for f in file_paths if str(f).endswith(".gguf")])
-    gguf = gguf_file is not None or (has_gguf and not has_safetensors)
     
-    if not gguf and (has_safetensors and has_gguf):
-        warnings.warn(
-            f"Both Safetensors and GGUF files have been found for {model_id} @ {revision}, if you want to estimate any of the GGUF file sizes, please use the `--gguf-file` flag with the path to the specific GGUF file. Estimation will continue for Safetensors files."
-        )
+
     # NOTE: GGUF support only applies if:
     # 1. The `--gguf-file` flag is set.
     # 2. No Safetensors files are found and at least one gguf file is found
+    gguf_paths = [f for f in file_paths if str(f).endswith(".gguf")]
+    has_safetensors = any(f in ["model.safetensors", "model.safetensors.index.json", "model_index.json"] for f in file_paths)
+    gguf = gguf_file is not None or (gguf_paths and not has_safetensors)
+    
+    if not gguf and (has_safetensors and gguf_paths):
+        warnings.warn(
+            f"Both Safetensors and GGUF files have been found for {model_id} @ {revision}, if you want to estimate any of the GGUF file sizes, please use the `--gguf-file` flag with the path to the specific GGUF file. GGUF files found: {gguf_paths}."
+        )
+
     if gguf:
         if kv_cache_dtype not in GGUFDtype.__members__ and kv_cache_dtype != "auto":
             raise RuntimeError(f"--kv-cache-dtype={kv_cache_dtype} not recognized for GGUF files. Valid options: {list(GGUFDtype.__members__.keys())} or `auto`.")
         
-        gguf_paths = [f for f in file_paths if str(f).endswith(".gguf")]
         if not gguf_paths:
             raise RuntimeError(f"No GGUF files found for {model_id} @ {revision}.")
         

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -547,7 +547,7 @@ def main() -> None:
         type=str,
         default="auto",
         # NOTE: https://docs.vllm.ai/en/stable/cli/serve/#-kv-cache-dtype
-        help=f"Data type for the KV cache storage. If `auto` is specified, it will use the default model dtype specified in the `config.json` (if available) or F16 for GGUF files. Despite the FP8 data types having different formats, all those take 1 byte, meaning that the calculation would lead to the same results. Valid values are {KV_CACHE_DTYPE_CHOICES} without for safetensors files and {["auto"] + list(GGUFDtype.__members__.keys())} for GGUF files. Defaults to `auto`.",
+        help=f"Data type for the KV cache storage. If `auto` is specified, it will use the default model dtype specified in the `config.json` (if available) or F16 for GGUF files. Despite the FP8 data types having different formats, all those take 1 byte, meaning that the calculation would lead to the same results. Valid values are {KV_CACHE_DTYPE_CHOICES} without for safetensors files and {['auto'] + list(GGUFDtype.__members__.keys())} for GGUF files. Defaults to `auto`.",
     )
 
     parser.add_argument(

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -16,7 +16,7 @@ from hf_mem import __version__
 from hf_mem.metadata import parse_safetensors_metadata
 from hf_mem.print import print_report, print_report_for_gguf
 from hf_mem.types import TorchDtypes, get_safetensors_dtype_bytes, torch_dtype_to_safetensors_dtype
-from hf_mem.gguf import fetch_gguf_metadata, gguf_metadata_to_json, merge_shards, GGUFMetadata, GGUFDtype
+from hf_mem.gguf import fetch_gguf_with_semaphore, gguf_metadata_to_json, merge_shards, GGUFMetadata, GGUFDtype
 
 # NOTE: Defines the bytes that will be fetched per safetensors file, but the metadata
 # can indeed be larger than that
@@ -149,7 +149,9 @@ async def run(
             if not gguf_paths:
                 raise RuntimeError(f"No GGUF file matching `{gguf_file}` found for {model_id} @ {revision}.")
 
-        gguf_files: Dict[str, GGUFMetadata] = dict()
+        semaphore = asyncio.Semaphore(MAX_CONCURRENCY)
+
+        tasks = []
         for path in gguf_paths:
             # In sharded GGUF files tensor metadata also gets sharded, so we need to merge them all
             shard_pattern = re.match(r'(.+)-(\d+)-of-(\d+)\.gguf$', str(path)) # Ex: Kimi-K2.5-BF16-00001-of-00046.gguf
@@ -158,17 +160,28 @@ async def run(
             if experimental and shard_pattern:
                 shard_num = int(shard_pattern.group(2)) # Get first number
                 parse_kv_cache = (shard_num == 1)
-
-            f_url = f"https://huggingface.co/{model_id}/resolve/{revision}/{str(path)}"
-            metadata = await fetch_gguf_metadata(
-                client=client, 
-                url=f_url, 
-                experimental=parse_kv_cache,
-                max_model_len=max_model_len,
-                kv_cache_dtype=kv_cache_dtype,
-                batch_size=batch_size,
-            )
             
+            task = asyncio.create_task(
+                fetch_gguf_with_semaphore(
+                    semaphore=semaphore,
+                    client=client,
+                    model_id=model_id,
+                    revision=revision,
+                    path=path,
+                    parse_kv_cache=parse_kv_cache,
+                    shard_pattern=shard_pattern,
+                    max_model_len=max_model_len,
+                    kv_cache_dtype=kv_cache_dtype,
+                    batch_size=batch_size,
+                    headers=headers,
+                )
+            )
+            tasks.append(task)
+
+        results = await asyncio.gather(*tasks, return_exceptions=False)
+
+        gguf_files: Dict[str, GGUFMetadata] = dict()
+        for path, metadata, shard_pattern in results:
             # Merge metadata for sharded files
             if shard_pattern:
                 # Ex: base_name = Kimi-K2.5-BF16
@@ -178,7 +191,7 @@ async def run(
                 else:
                     gguf_files[base_name] = metadata
             else:
-                gguf_files[str(path)] = metadata 
+                gguf_files[path] = metadata 
         
         
         if json_output:

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -95,6 +95,7 @@ async def run(
     json_output: bool = False,
     ignore_table_width: bool = False,
     gguf: bool = False,
+    gguf_file: str | None = None,
 ) -> Dict[str, Any] | None:
     headers = {"User-Agent": f"hf-mem/0.4; id={uuid4()}; model_id={model_id}; revision={revision}"}
     # NOTE: Read from `HF_TOKEN` if provided, then fallback to reading from `$HF_HOME/token`
@@ -128,11 +129,26 @@ async def run(
     file_paths = [f["path"] for f in files if f.get("path") and f.get("type") == "file"]
 
     # GGUF support
-    if gguf:
+    if gguf or gguf_file is not None:
         gguf_paths = [f for f in file_paths if str(f).endswith(".gguf")]
         if not gguf_paths:
             raise RuntimeError(f"No GGUF files found for {model_id} @ {revision}.")
         
+        if gguf_file:
+            # Check if it's a sharded file (model-00001-of-00046.gguf)
+            if prefix_match := re.match(r'(.+)-\d+-of-\d+\.gguf$', gguf_file):
+                # Keep all shards with the same prefix
+                prefix = prefix_match.group(1)
+                gguf_paths = [path for path in gguf_paths if re.match(rf'{re.escape(prefix)}-\d+-of-\d+\.gguf$', str(path))]
+            else:
+                # Not sharded
+                gguf_paths = [path for path in gguf_paths if str(path).endswith(gguf_file)]
+                if len(gguf_paths) > 1:
+                    raise RuntimeError(f"Multiple GGUF files named `{gguf_file}` found for {model_id} @ {revision}.")
+            
+            if not gguf_paths:
+                raise RuntimeError(f"No GGUF file matching `{gguf_file}` found for {model_id} @ {revision}.")
+
         gguf_files: Dict[str, GGUFMetadata] = dict()
         for path in gguf_paths:
             # In sharded GGUF files tensor metadata also gets sharded, so we need to merge them all
@@ -169,15 +185,42 @@ async def run(
             print(
                 json.dumps([
                     gguf_metadata_to_json(
-                        model_id=model_id, 
+                        model_id=filename, 
                         revision=revision, 
                         metadata=gguf_metadata
                     ) 
-                    for gguf_metadata in gguf_files.values()
+                    for filename, gguf_metadata in gguf_files.items()
                 ])
             )
         else:
-            print_report_for_gguf(
+            if gguf_file:
+                gguf_metadata = list(gguf_files.values())[0]
+                gguf_file_name = list(gguf_files.keys())[0]
+
+                # If we print just one file, we reuse the print_report function
+                if experimental and gguf_metadata.kv_cache_info is not None:
+                    print_report(
+                        model_id=gguf_file_name,
+                        revision=revision,
+                        metadata=gguf_metadata,
+                        cache={
+                            "max_model_len": gguf_metadata.kv_cache_info.max_model_len,
+                            "cache_size": gguf_metadata.kv_cache_info.cache_size,
+                            "batch_size": gguf_metadata.kv_cache_info.batch_size,
+                            "cache_dtype": gguf_metadata.kv_cache_info.cache_dtype,  # type: ignore
+                        },
+                        ignore_table_width=ignore_table_width,
+                    )
+                else:
+                    print_report(
+                        model_id=gguf_file_name,
+                        revision=revision,
+                        metadata=gguf_metadata,
+                        ignore_table_width=ignore_table_width,
+                    )
+            else:
+                # For multiple files, we use the new one
+                print_report_for_gguf(
                 model_id=model_id,
                 revision=revision,
                 gguf_files=gguf_files,
@@ -509,6 +552,12 @@ def main() -> None:
         action="store_true",
         help="Whether to parse GGUF files instead of Safetensors ones.",
     )
+    parser.add_argument(
+        "--gguf-file",
+        type=str,
+        default=None,
+        help="Specific GGUF file to estimate. If not provided, all GGUF files found in the repo will be estimated. Only the file name is required, not the full path.",
+    )
     args = parser.parse_args()
 
     if args.experimental:
@@ -516,7 +565,7 @@ def main() -> None:
             "`--experimental` is set, which means that models with an architecture as `...ForCausalLM` and `...ForConditionalGeneration` will include estimations for the KV Cache as well. You can also provide the args `--max-model-len` and `--batch-size` as part of the estimation. Note that enabling `--experimental` means that the output will be different both when displayed and when dumped as JSON with `--json-output`, so bear that in mind."
         )
     
-    if args.gguf:
+    if args.gguf or args.gguf_file is not None:
         if args.kv_cache_dtype not in GGUFDtype.__members__ and args.kv_cache_dtype != "auto":
             raise RuntimeError(f"--kv-cache-dtype={args.kv_cache_dtype} not recognized for GGUF files. Valid options: {list(GGUFDtype.__members__.keys())} or `auto`.")
     else:
@@ -537,5 +586,6 @@ def main() -> None:
             ignore_table_width=args.ignore_table_width,
             # GGUF flag
             gguf=args.gguf,
+            gguf_file=args.gguf_file
         )
     )

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -94,7 +94,6 @@ async def run(
     # END_KV_CACHE_ARGS
     json_output: bool = False,
     ignore_table_width: bool = False,
-    gguf: bool = False,
     gguf_file: str | None = None,
 ) -> Dict[str, Any] | None:
     headers = {"User-Agent": f"hf-mem/0.4; id={uuid4()}; model_id={model_id}; revision={revision}"}
@@ -128,8 +127,21 @@ async def run(
     files = await get_json_file(client=client, url=url, headers=headers)
     file_paths = [f["path"] for f in files if f.get("path") and f.get("type") == "file"]
 
-    # GGUF support
-    if gguf or gguf_file is not None:
+    has_safetensors = any(f in ["model.safetensors", "model.safetensors.index.json", "model_index.json"] for f in file_paths)
+    has_gguf = any([f for f in file_paths if str(f).endswith(".gguf")])
+    gguf = gguf_file is not None or (has_gguf and not has_safetensors)
+    
+    if not gguf and (has_safetensors and has_gguf):
+        warnings.warn(
+            f"Both Safetensors and GGUF files have been found for {model_id} @ {revision}, if you want to estimate any of the GGUF file sizes, please use the `--gguf-file` flag with the path to the specific GGUF file. Estimation will continue for Safetensors files."
+        )
+    # NOTE: GGUF support only applies if:
+    # 1. The `--gguf-file` flag is set.
+    # 2. No Safetensors files are found and at least one gguf file is found
+    if gguf:
+        if kv_cache_dtype not in GGUFDtype.__members__ and kv_cache_dtype != "auto":
+            raise RuntimeError(f"--kv-cache-dtype={kv_cache_dtype} not recognized for GGUF files. Valid options: {list(GGUFDtype.__members__.keys())} or `auto`.")
+        
         gguf_paths = [f for f in file_paths if str(f).endswith(".gguf")]
         if not gguf_paths:
             raise RuntimeError(f"No GGUF files found for {model_id} @ {revision}.")
@@ -561,11 +573,6 @@ def main() -> None:
         help="Whether to ignore the maximum recommended table width, in case the `--model-id` and/or `--revision` cause a row overflow when printing those.",
     )
     parser.add_argument(
-        "--gguf",
-        action="store_true",
-        help="Whether to parse GGUF files instead of Safetensors ones.",
-    )
-    parser.add_argument(
         "--gguf-file",
         type=str,
         default=None,
@@ -578,12 +585,8 @@ def main() -> None:
             "`--experimental` is set, which means that models with an architecture as `...ForCausalLM` and `...ForConditionalGeneration` will include estimations for the KV Cache as well. You can also provide the args `--max-model-len` and `--batch-size` as part of the estimation. Note that enabling `--experimental` means that the output will be different both when displayed and when dumped as JSON with `--json-output`, so bear that in mind."
         )
     
-    if args.gguf or args.gguf_file is not None:
-        if args.kv_cache_dtype not in GGUFDtype.__members__ and args.kv_cache_dtype != "auto":
-            raise RuntimeError(f"--kv-cache-dtype={args.kv_cache_dtype} not recognized for GGUF files. Valid options: {list(GGUFDtype.__members__.keys())} or `auto`.")
-    else:
-        if args.kv_cache_dtype not in KV_CACHE_DTYPE_CHOICES:
-            raise RuntimeError(f"--kv-cache-dtype={args.kv_cache_dtype} not recognized. Valid options: {KV_CACHE_DTYPE_CHOICES}.")
+    if args.kv_cache_dtype not in KV_CACHE_DTYPE_CHOICES:
+        raise RuntimeError(f"--kv-cache-dtype={args.kv_cache_dtype} not recognized. Valid options: {KV_CACHE_DTYPE_CHOICES}.")
 
     asyncio.run(
         run(
@@ -597,8 +600,7 @@ def main() -> None:
             # NOTE: Below are the arguments that affect the output format
             json_output=args.json_output,
             ignore_table_width=args.ignore_table_width,
-            # GGUF flag
-            gguf=args.gguf,
+            # NOTE: GGUF flags
             gguf_file=args.gguf_file
         )
     )

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -218,14 +218,24 @@ async def run(
                 gguf_files[path] = metadata
 
         if json_output:
-            print(
-                json.dumps(
-                    [
-                        gguf_metadata_to_json(model_id=filename, revision=revision, metadata=gguf_metadata)
-                        for filename, gguf_metadata in gguf_files.items()
-                    ]
+            if gguf_file:
+                print(
+                    json.dumps(
+                        [
+                            gguf_metadata_to_json(model_id=filename, revision=revision, metadata=gguf_metadata)
+                            for filename, gguf_metadata in gguf_files.items()
+                        ][0]
+                    )
                 )
-            )
+            else:
+                print(
+                    json.dumps(
+                        [
+                            gguf_metadata_to_json(model_id=filename, revision=revision, metadata=gguf_metadata)
+                            for filename, gguf_metadata in gguf_files.items()
+                        ]
+                    )
+                )
         else:
             if gguf_file:
                 gguf_metadata = list(gguf_files.values())[0]

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -16,13 +16,14 @@ from hf_mem import __version__
 from hf_mem.metadata import parse_safetensors_metadata
 from hf_mem.print import print_report, print_report_for_gguf
 from hf_mem.types import TorchDtypes, get_safetensors_dtype_bytes, torch_dtype_to_safetensors_dtype
-from hf_mem.gguf import fetch_gguf_metadata, gguf_metadata_to_json, GGUFMetadata, merge_shards
+from hf_mem.gguf import fetch_gguf_metadata, gguf_metadata_to_json, merge_shards, GGUFMetadata, GGUFDtype
 
 # NOTE: Defines the bytes that will be fetched per safetensors file, but the metadata
 # can indeed be larger than that
 MAX_METADATA_SIZE = 100_000
 REQUEST_TIMEOUT = float(os.getenv("REQUEST_TIMEOUT", 30.0))
 MAX_CONCURRENCY = int(os.getenv("MAX_WORKERS", min(32, (os.cpu_count() or 1) + 4)))
+KV_CACHE_DTYPE_CHOICES = ["auto", "bfloat16", "fp8", "fp8_ds_mla", "fp8_e4m3", "fp8_e5m2", "fp8_inc"]
 
 
 # NOTE: Return type-hint set to `Any`, but it will only be a JSON-compatible object
@@ -490,11 +491,7 @@ def main() -> None:
         type=str,
         default="auto",
         # NOTE: https://docs.vllm.ai/en/stable/cli/serve/#-kv-cache-dtype
-        # TODO: Might want to change this since --kv-cache-dtype for .GGUF files does not support most of 
-        # these options. It only supports a subset from the ones listed in GGUFDtype enum.
-        # Source: https://github.com/ggml-org/llama.cpp/issues/10373
-        choices={"auto", "bfloat16", "fp8", "fp8_ds_mla", "fp8_e4m3", "fp8_e5m2", "fp8_inc"},
-        help="Data type for the KV cache storage. If `auto` is specified, it will use the default model dtype specified in the `config.json` (if available). Despite the FP8 data types having different formats, all those take 1 byte, meaning that the calculation would lead to the same results. Defaults to `auto`.",
+        help=f"Data type for the KV cache storage. If `auto` is specified, it will use the default model dtype specified in the `config.json` (if available) or F16 for GGUF files. Despite the FP8 data types having different formats, all those take 1 byte, meaning that the calculation would lead to the same results. Valid values are {KV_CACHE_DTYPE_CHOICES} without for safetensors files and {["auto"] + list(GGUFDtype.__members__.keys())} for GGUF files. Defaults to `auto`.",
     )
 
     parser.add_argument(
@@ -518,6 +515,13 @@ def main() -> None:
         warnings.warn(
             "`--experimental` is set, which means that models with an architecture as `...ForCausalLM` and `...ForConditionalGeneration` will include estimations for the KV Cache as well. You can also provide the args `--max-model-len` and `--batch-size` as part of the estimation. Note that enabling `--experimental` means that the output will be different both when displayed and when dumped as JSON with `--json-output`, so bear that in mind."
         )
+    
+    if args.gguf:
+        if args.kv_cache_dtype not in GGUFDtype.__members__ and args.kv_cache_dtype != "auto":
+            raise RuntimeError(f"--kv-cache-dtype={args.kv_cache_dtype} not recognized for GGUF files. Valid options: {list(GGUFDtype.__members__.keys())} or `auto`.")
+    else:
+        if args.kv_cache_dtype not in KV_CACHE_DTYPE_CHOICES:
+            raise RuntimeError(f"--kv-cache-dtype={args.kv_cache_dtype} not recognized. Valid options: {KV_CACHE_DTYPE_CHOICES}.")
 
     asyncio.run(
         run(

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -13,7 +13,7 @@ import httpx
 
 from hf_mem import __version__
 from hf_mem.metadata import parse_safetensors_metadata
-from hf_mem.print import print_report
+from hf_mem.print import print_report, print_report_for_gguf
 from hf_mem.types import TorchDtypes, get_safetensors_dtype_bytes, torch_dtype_to_safetensors_dtype
 
 # NOTE: Defines the bytes that will be fetched per safetensors file, but the metadata
@@ -236,9 +236,25 @@ async def run(
 
         metadata = parse_safetensors_metadata(raw_metadata=raw_metadata)
     else:
-        raise RuntimeError(
-            "NONE OF `model.safetensors`, `model.safetensors.index.json`, `model_index.json` HAS BEEN FOUND"
-        )
+        # Check for GGUF files
+        gguf_files = {
+            f["path"]: f["size"]
+            for f in files
+            if f.get("path", "").endswith(".gguf") and f.get("size") is not None
+        }
+
+        if gguf_files:
+            print_report_for_gguf(
+                model_id=model_id,
+                revision=revision,
+                gguf_files=gguf_files,
+                ignore_table_width=ignore_table_width,
+            )
+            return
+        else:
+            raise RuntimeError(
+                "NONE OF `model.safetensors`, `model.safetensors.index.json`, `model_index.json`, OR `.gguf` FILES HAVE BEEN FOUND"
+            )
 
     cache_size = None
     if experimental:

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -124,6 +124,8 @@ async def run(
 
     # TODO: `recursive=true` shouldn't really be required unless it's a Diffusers
     # models... I don't think this adds extra latency anyway
+    # NOTE: `recursive=true` is also need for GGUF file directories where each 
+    # sharded quantization is inside a different folder like: Q2_K/model_Q2_K-0001-of-0048.gguf
     url = f"https://huggingface.co/api/models/{model_id}/tree/{revision}?recursive=true"
     files = await get_json_file(client=client, url=url, headers=headers)
     file_paths = [f["path"] for f in files if f.get("path") and f.get("type") == "file"]
@@ -136,22 +138,28 @@ async def run(
         
         gguf_files: Dict[str, GGUFMetadata] = dict()
         for path in gguf_paths:
+            # In sharded GGUF files tensor metadata also gets sharded, so we need to merge them all
+            shard_pattern = re.match(r'(.+)-(\d+)-of-(\d+)\.gguf$', str(path)) # Ex: Kimi-K2.5-BF16-00001-of-00046.gguf
+            parse_kv_cache = True
+            # For sharded files, parsing kv_cache data might result in runtime errors (missing fields)
+            if shard_pattern:
+                shard_num = int(shard_pattern.group(2)) # Get first number
+                parse_kv_cache = (shard_num == 1)
+
             f_url = f"https://huggingface.co/{model_id}/resolve/{revision}/{str(path)}"
             metadata = await fetch_gguf_metadata(
                 client=client, 
                 url=f_url, 
-                experimental=experimental,
+                experimental=parse_kv_cache,
                 max_model_len=max_model_len,
                 kv_cache_dtype=kv_cache_dtype,
                 batch_size=batch_size,
             )
-
-            # In sharded GGUF files tensor metadata also gets sharded, so we need to merge them all
-            shard_pattern = re.match(r'(.+)-\d+-of-\d+\.gguf$', str(path)) # Ex: Kimi-K2.5-BF16-00001-of-00046.gguf
+            
+            # Merge metadata for sharded files
             if shard_pattern:
                 # Ex: base_name = Kimi-K2.5-BF16
                 base_name = shard_pattern.group(1) + ".gguf"
-                print(base_name)
                 if base_name in gguf_files:
                     gguf_files[base_name] = merge_shards(gguf_files[base_name], metadata)
                 else:
@@ -486,6 +494,9 @@ def main() -> None:
         type=str,
         default="auto",
         # NOTE: https://docs.vllm.ai/en/stable/cli/serve/#-kv-cache-dtype
+        # TODO: Might want to change this since --kv-cache-dtype for .GGUF files does not support most of 
+        # these options. It only supports a subset from the ones listed in GGUFDtype enum.
+        # Source: https://github.com/ggml-org/llama.cpp/issues/10373
         choices={"auto", "bfloat16", "fp8", "fp8_ds_mla", "fp8_e4m3", "fp8_e5m2", "fp8_inc"},
         help="Data type for the KV cache storage. If `auto` is specified, it will use the default model dtype specified in the `config.json` (if available). Despite the FP8 data types having different formats, all those take 1 byte, meaning that the calculation would lead to the same results. Defaults to `auto`.",
     )

--- a/src/hf_mem/gguf.py
+++ b/src/hf_mem/gguf.py
@@ -1,11 +1,31 @@
-GGUFDtypeBitsPerWeight = {
-    "F64": 64,
-    "I64": 64,
-    "F32": 32,
-    "I32": 32,
-    "F16": 16,
-    "BF16": 16,
-    "I16": 16,
+from dataclasses import dataclass
+from typing import Literal, Dict, TypeGuard
+from hf_mem.metadata import DtypeMetadata
+
+GGUFDtypes = Literal[
+    "F64", "I64",
+    "F32", "I32",
+    "F16", "BF16", "I16",
+    # .GGUF specific dtypes
+    "Q8_K", "Q6_K", "Q5_K", "Q4_K", "Q3_K", "Q2_K",
+    "IQ4_NL", "IQ4_XS", 
+    "IQ3_S", "IQ3_XXS", 
+    "IQ2_XXS", "IQ2_S", "IQ2_XS",
+    "IQ1_S", "IQ1_M",
+    "TQ1_0", "TQ2_0",
+    "MXFP4",
+    # .GGUF specific dtypes (legacy type, added for exhaustivity)
+    "Q8_0", "Q8_1", "Q5_0", "Q5_1", "Q4_0", "Q4_1",
+]
+
+GGUFDtypeBitsPerWeight: Dict[GGUFDtypes, float] = {
+    "F64": 64.0,
+    "I64": 64.0,
+    "F32": 32.0,
+    "I32": 32.0,
+    "F16": 16.0,
+    "BF16": 16.0,
+    "I16": 16.0,
     # .GGUF specific dtypes
     "Q8_K": 8.03125,
     "Q6_K": 6.5625,
@@ -27,15 +47,35 @@ GGUFDtypeBitsPerWeight = {
     "MXFP4": 4.25,
     # .GGUF specific dtypes (legacy type, added for exhaustivity)
     "Q8_0": 8.5,
-    "Q8_1": 9,
+    "Q8_1": 9.0,
     "Q5_0": 5.5,
-    "Q5_1": 6,
+    "Q5_1": 6.0,
     "Q4_0": 4.5,
-    "Q4_1": 5,
+    "Q4_1": 5.0,
 }
 
+
+# Very similar to ComponentMetadata, might want to generalize it / create father type of GGUFDtypes
+@dataclass
+class GGUFComponentMetadata:
+    dtypes: Dict[GGUFDtypes, DtypeMetadata]
+    param_count: int
+    bytes_count: int
+
+# Very similar to SafetensorsMetadata
+@dataclass
+class GGUFMetadata:
+    components: Dict[str, GGUFComponentMetadata]
+    param_count: int
+    bytes_count: int
+
+
+def is_gguf_dtype(value: str) -> TypeGuard[GGUFDtypes]:
+    return value in GGUFDtypeBitsPerWeight
+
+
 def get_gguf_dtype_bytes(dtype: str) -> float:
-    if dtype not in GGUFDtypeBitsPerWeight.keys():
+    if not is_gguf_dtype(dtype):
         raise RuntimeError(f"DTYPE={dtype} NOT HANDLED")
     
     return GGUFDtypeBitsPerWeight[dtype] / 8.0 # bit to byte conversion

--- a/src/hf_mem/gguf.py
+++ b/src/hf_mem/gguf.py
@@ -1,81 +1,283 @@
 from dataclasses import dataclass
-from typing import Literal, Dict, TypeGuard
-from hf_mem.metadata import DtypeMetadata
+from typing import Dict, Optional, Any, Callable
+from enum import IntEnum
+import httpx
+import struct
+import math
+from hf_mem.cli import REQUEST_TIMEOUT
 
-GGUFDtypes = Literal[
-    "F64", "I64",
-    "F32", "I32",
-    "F16", "BF16", "I16",
-    # .GGUF specific dtypes
-    "Q8_K", "Q6_K", "Q5_K", "Q4_K", "Q3_K", "Q2_K",
-    "IQ4_NL", "IQ4_XS", 
-    "IQ3_S", "IQ3_XXS", 
-    "IQ2_XXS", "IQ2_S", "IQ2_XS",
-    "IQ1_S", "IQ1_M",
-    "TQ1_0", "TQ2_0",
-    "MXFP4",
-    # .GGUF specific dtypes (legacy type, added for exhaustivity)
-    "Q8_0", "Q8_1", "Q5_0", "Q5_1", "Q4_0", "Q4_1",
-]
+SIZES = [100_000, 1_000_000, 10_000_000, 50_000_000, 100_000_000]
 
-GGUFDtypeBitsPerWeight: Dict[GGUFDtypes, float] = {
-    "F64": 64.0,
-    "I64": 64.0,
-    "F32": 32.0,
-    "I32": 32.0,
-    "F16": 16.0,
-    "BF16": 16.0,
-    "I16": 16.0,
+# --- GGUF Dtypes (weights) ---
+class GGUFDtype(IntEnum):
+    F32 = 0
+    F16 = 1
+    Q4_0 = 2
+    Q4_1 = 3
+    # Q4_2 = 4
+    # Q4_3 = 5
+    Q5_0 = 6
+    Q5_1 = 7
+    Q8_0 = 8
+    Q8_1 = 9
+    Q2_K = 10
+    Q3_K = 11
+    Q4_K = 12
+    Q5_K = 13
+    Q6_K = 14
+    Q8_K = 15
+    IQ2_XXS = 16
+    IQ2_XS = 17
+    IQ3_XXS = 18
+    IQ1_S = 19
+    IQ4_NL = 20
+    IQ3_S = 21
+    IQ2_S = 22
+    IQ4_XS = 23
+    I8 = 24
+    I16 = 25
+    I32 = 26
+    I64 = 27
+    F64 = 28
+    IQ1_M = 29
+    BF16 = 30
+    # Q4_0_4_4
+    # Q4_0_4_8
+    # Q4_0_8_8
+    TQ1_0 = 34
+    TQ2_0 = 35
+    # IQ4_NL_4_4 = 36
+    # IQ4_NL_4_8 = 37
+    # IQ4_NL_8_8 = 38
+    MXFP4 = 39
+    COUNT = 40 # For exhaustivity, not used
+
+# Conversion .gguf weight dtype -> bits-per-weight
+GGUFDtypeBitsPerWeight: Dict[GGUFDtype, float] = {
+    GGUFDtype.F64: 64.0,
+    GGUFDtype.I64: 64.0,
+    GGUFDtype.F32: 32.0,
+    GGUFDtype.I32: 32.0,
+    GGUFDtype.F16: 16.0,
+    GGUFDtype.BF16: 16.0,
+    GGUFDtype.I16: 16.0,
     # .GGUF specific dtypes
-    "Q8_K": 8.03125,
-    "Q6_K": 6.5625,
-    "Q5_K": 5.5,
-    "Q4_K": 4.5,
-    "Q3_K": 3.4375,
-    "Q2_K": 2.625,
-    "IQ4_NL": 4.5,
-    "IQ4_XS": 4.25,
-    "IQ3_S": 3.44,
-    "IQ3_XXS": 3.06,
-    "IQ2_XXS": 2.06,
-    "IQ2_S": 2.5,
-    "IQ2_XS": 2.31,
-    "IQ1_S": 1.56,
-    "IQ1_M": 1.75,
-    "TQ1_0": 1.6875,
-    "TQ2_0": 2.0625,
-    "MXFP4": 4.25,
+    GGUFDtype.Q8_K: 8.03125,
+    GGUFDtype.Q6_K: 6.5625,
+    GGUFDtype.Q5_K: 5.5,
+    GGUFDtype.Q4_K: 4.5,
+    GGUFDtype.Q3_K: 3.4375,
+    GGUFDtype.Q2_K: 2.625,
+    GGUFDtype.IQ4_NL: 4.5,
+    GGUFDtype.IQ4_XS: 4.25,
+    GGUFDtype.IQ3_S: 3.44,
+    GGUFDtype.IQ3_XXS: 3.06,
+    GGUFDtype.IQ2_XXS: 2.06,
+    GGUFDtype.IQ2_S: 2.5,
+    GGUFDtype.IQ2_XS: 2.31,
+    GGUFDtype.IQ1_S: 1.56,
+    GGUFDtype.IQ1_M: 1.75,
+    GGUFDtype.TQ1_0: 1.6875,
+    GGUFDtype.TQ2_0: 2.0625,
+    GGUFDtype.MXFP4: 4.25,
     # .GGUF specific dtypes (legacy type, added for exhaustivity)
-    "Q8_0": 8.5,
-    "Q8_1": 9.0,
-    "Q5_0": 5.5,
-    "Q5_1": 6.0,
-    "Q4_0": 4.5,
-    "Q4_1": 5.0,
+    GGUFDtype.Q8_0: 8.5,
+    GGUFDtype.Q8_1: 9.0,
+    GGUFDtype.Q5_0: 5.5,
+    GGUFDtype.Q5_1: 6.0,
+    GGUFDtype.Q4_0: 4.5,
+    GGUFDtype.Q4_1: 5.0,
 }
 
 
-# Very similar to ComponentMetadata, might want to generalize it / create father type of GGUFDtypes
+# --- Auxiliary read functions ---
+# Related to .gguf metadata dtypes, not weights dtypes
+def _read_string(raw_metadata: bytes, offset: int) -> tuple[str, int]:
+    length = struct.unpack("<Q", raw_metadata[offset:offset+8])[0]
+    offset += 8
+    key = raw_metadata[offset:offset+length].decode()
+    offset += length
+    return key, offset
+
+def _read_uint8(raw_metadata: bytes, offset: int) -> tuple[int, int]:
+    value = struct.unpack("<B", raw_metadata[offset:offset+1])[0]
+    offset += 1
+    return value, offset
+
+def _read_int8(raw_metadata: bytes, offset: int) -> tuple[int, int]:
+    value = struct.unpack("<b", raw_metadata[offset:offset+1])[0]
+    offset += 1
+    return value, offset
+
+def _read_uint16(raw_metadata: bytes, offset: int) -> tuple[int, int]:
+    value = struct.unpack("<H", raw_metadata[offset:offset+2])[0]
+    offset += 2
+    return value, offset
+
+def _read_int16(raw_metadata: bytes, offset: int) -> tuple[int, int]:
+    value = struct.unpack("<h", raw_metadata[offset:offset+2])[0]
+    offset += 2
+    return value, offset
+
+def _read_uint32(raw_metadata: bytes, offset: int) -> tuple[int, int]:
+    value = struct.unpack("<I", raw_metadata[offset:offset+4])[0]
+    offset += 4
+    return value, offset
+
+def _read_int32(raw_metadata: bytes, offset: int) -> tuple[int, int]:
+    value = struct.unpack("<i", raw_metadata[offset:offset+4])[0]
+    offset += 4
+    return value, offset
+
+def _read_float32(raw_metadata: bytes, offset: int) -> tuple[float, int]:
+    value = struct.unpack("<f", raw_metadata[offset:offset+4])[0]
+    offset += 4
+    return value, offset
+
+def _read_bool(raw_metadata: bytes, offset: int) -> tuple[bool, int]:
+    value = struct.unpack("<?", raw_metadata[offset:offset+1])[0]
+    offset += 1
+    return value, offset
+
+def _read_array(raw_metadata: bytes, offset: int) -> tuple[list[Any], int]:
+    value_type = struct.unpack("<I", raw_metadata[offset:offset+4])[0]
+    offset += 4
+    length = struct.unpack("<Q", raw_metadata[offset:offset+8])[0]
+    offset += 8
+    value = []
+    for i in range(length):
+        sub_value, offset = Parsers[value_type](raw_metadata, offset)
+        value.append(sub_value)
+    return value, offset
+
+def _read_uint64(raw_metadata: bytes, offset: int) -> tuple[int, int]:
+    value = struct.unpack("<Q", raw_metadata[offset:offset+8])[0]
+    offset += 8
+    return value, offset
+
+def _read_int64(raw_metadata: bytes, offset: int) -> tuple[int, int]:
+    value = struct.unpack("<q", raw_metadata[offset:offset+8])[0]
+    offset += 8
+    return value, offset
+
+def _read_float64(raw_metadata: bytes, offset: int) -> tuple[float, int]:
+    value = struct.unpack("<d", raw_metadata[offset:offset+8])[0]
+    offset += 8
+    return value, offset
+
+# --- GGUF Metadata Dtypes ---
+# Related to .gguf metadata dtypes, not weights dtypes
+class GGUFMetadataDtype(IntEnum):
+    UINT8 = 0
+    INT8 = 1
+    UINT16 = 2
+    INT16 = 3
+    UINT32 = 4
+    INT32 = 5
+    FLOAT32 = 6
+    BOOL = 7
+    STRING = 8
+    ARRAY = 9
+    UINT64 = 10
+    INT64 = 11
+    FLOAT64 = 12
+
+Parsers: Dict[GGUFMetadataDtype, Callable] = {
+    GGUFMetadataDtype.UINT8: _read_uint8,
+    GGUFMetadataDtype.INT8: _read_int8,
+    GGUFMetadataDtype.UINT16: _read_uint16,
+    GGUFMetadataDtype.INT16: _read_int16,
+    GGUFMetadataDtype.UINT32: _read_uint32,
+    GGUFMetadataDtype.INT32: _read_int32,
+    GGUFMetadataDtype.FLOAT32: _read_float32,
+    GGUFMetadataDtype.BOOL: _read_bool,
+    GGUFMetadataDtype.STRING: _read_string,
+    GGUFMetadataDtype.ARRAY: _read_array,
+    GGUFMetadataDtype.UINT64: _read_uint64,
+    GGUFMetadataDtype.INT64: _read_int64,
+    GGUFMetadataDtype.FLOAT64: _read_float64,
+}
+
+@dataclass
+class GGUFDtypeMetadata:
+    param_count: int
+    bytes_count: float
+
 @dataclass
 class GGUFComponentMetadata:
-    dtypes: Dict[GGUFDtypes, DtypeMetadata]
+    dtypes: Dict[GGUFDtype, GGUFDtypeMetadata]
     param_count: int
-    bytes_count: int
+    bytes_count: float
 
-# Very similar to SafetensorsMetadata
 @dataclass
 class GGUFMetadata:
     components: Dict[str, GGUFComponentMetadata]
     param_count: int
-    bytes_count: int
+    bytes_count: float
 
 
-def is_gguf_dtype(value: str) -> TypeGuard[GGUFDtypes]:
-    return value in GGUFDtypeBitsPerWeight
+def parse_gguf_metadata(raw_metadata: bytes) -> GGUFMetadata:
+    # Header
+    magic = raw_metadata[:4].decode("ascii")
+    version = struct.unpack("<I", raw_metadata[4:8])[0]
+    tensor_count = struct.unpack("<Q", raw_metadata[8:16])[0]
+    metadata_kv_count = struct.unpack("<Q", raw_metadata[16:24])[0]
+    offset = 24
 
-
-def get_gguf_dtype_bytes(dtype: str) -> float:
-    if not is_gguf_dtype(dtype):
-        raise RuntimeError(f"DTYPE={dtype} NOT HANDLED")
+    # KV Cache Metadata
+    for i in range(metadata_kv_count):
+        # Key
+        key, offset = _read_string(raw_metadata, offset)
+        value_type = version = struct.unpack("<I", raw_metadata[offset:offset+4])[0]
+        offset += 4
+        value, offset = Parsers[value_type](raw_metadata, offset)
     
-    return GGUFDtypeBitsPerWeight[dtype] / 8.0 # bit to byte conversion
+    # Tensor info
+    component = GGUFComponentMetadata(dtypes={}, param_count=0, bytes_count=0)
+    for i in range(tensor_count):
+        name, offset = _read_string(raw_metadata, offset)
+        n_dimensions, offset = _read_uint32(raw_metadata, offset)
+        dimensions = []
+        for _ in range(n_dimensions):
+            dim, offset = _read_uint64(raw_metadata, offset)
+            dimensions.append(dim)
+        tensor_type, offset = _read_uint32(raw_metadata, offset)
+        tensor_offset, offset = _read_uint64(raw_metadata, offset)
+
+        param_count = math.prod(dimensions)
+        bytes_count = GGUFDtypeBitsPerWeight[GGUFDtype(tensor_type)] / 8.0 * param_count
+        if GGUFDtype(tensor_type) in component.dtypes:
+            dtype = component.dtypes[GGUFDtype(tensor_type)]
+            dtype.param_count += param_count
+            dtype.bytes_count += bytes_count
+        else:
+            component.dtypes[GGUFDtype(tensor_type)] = GGUFDtypeMetadata(
+                param_count=param_count,
+                bytes_count=bytes_count,
+            )
+        component.param_count += param_count
+        component.bytes_count += bytes_count
+
+    return GGUFMetadata(
+        components={"Transformer": component},
+        param_count=component.param_count,
+        bytes_count=component.bytes_count,
+    )
+
+
+async def fetch_gguf_metadata(
+    client: httpx.AsyncClient, url: str, headers: Optional[Dict[str, str]] = None
+) -> GGUFMetadata:
+    for size in SIZES:
+        try: 
+            request_headers = {"Range": f"bytes=0-{size}", **(headers or {})}
+            response = await client.get(url, headers=request_headers, timeout=REQUEST_TIMEOUT)
+            response.raise_for_status()
+
+            raw_metadata = response.read()
+            processed_metadata = parse_gguf_metadata(raw_metadata)
+            return processed_metadata
+        except (struct.error, UnicodeDecodeError):
+            if size == SIZES[-1]:
+                raise RuntimeError(f"Failed to parse GGUF metadata from {url}, metadata larger than {size/1_000_000:.2f} MB.")
+            continue

--- a/src/hf_mem/gguf.py
+++ b/src/hf_mem/gguf.py
@@ -1,0 +1,41 @@
+GGUFDtypeBitsPerWeight = {
+    "F64": 64,
+    "I64": 64,
+    "F32": 32,
+    "I32": 32,
+    "F16": 16,
+    "BF16": 16,
+    "I16": 16,
+    # .GGUF specific dtypes
+    "Q8_K": 8.03125,
+    "Q6_K": 6.5625,
+    "Q5_K": 5.5,
+    "Q4_K": 4.5,
+    "Q3_K": 3.4375,
+    "Q2_K": 2.625,
+    "IQ4_NL": 4.5,
+    "IQ4_XS": 4.25,
+    "IQ3_S": 3.44,
+    "IQ3_XXS": 3.06,
+    "IQ2_XXS": 2.06,
+    "IQ2_S": 2.5,
+    "IQ2_XS": 2.31,
+    "IQ1_S": 1.56,
+    "IQ1_M": 1.75,
+    "TQ1_0": 1.6875,
+    "TQ2_0": 2.0625,
+    "MXFP4": 4.25,
+    # .GGUF specific dtypes (legacy type, added for exhaustivity)
+    "Q8_0": 8.5,
+    "Q8_1": 9,
+    "Q5_0": 5.5,
+    "Q5_1": 6,
+    "Q4_0": 4.5,
+    "Q4_1": 5,
+}
+
+def get_gguf_dtype_bytes(dtype: str) -> float:
+    if dtype not in GGUFDtypeBitsPerWeight.keys():
+        raise RuntimeError(f"DTYPE={dtype} NOT HANDLED")
+    
+    return GGUFDtypeBitsPerWeight[dtype] / 8.0 # bit to byte conversion

--- a/src/hf_mem/gguf.py
+++ b/src/hf_mem/gguf.py
@@ -314,16 +314,16 @@ def compute_gguf_kv_cache_size(
     if kv_cache_dtype is not None:
         if kv_cache_dtype not in GGUFDtype.__members__:
             raise RuntimeError(f"--kv-cache-dtype={kv_cache_dtype} not recognized for GGUF KV cache size estimation. Valid options: {list(GGUFDtype.__members__.keys())}.")
-        total_size = (
+        total_size = int(
             block_count 
             * size_per_token 
             * context_length 
             * batch_size 
-            * int(GGUFDtypeBitsPerWeight[GGUFDtype[kv_cache_dtype]] / 8.0)
+            * GGUFDtypeBitsPerWeight[GGUFDtype[kv_cache_dtype]] / 8.0
         )
     else:
         # Default to F16 size
-        total_size = (
+        total_size = int(
             block_count 
             * size_per_token 
             * context_length 

--- a/src/hf_mem/gguf.py
+++ b/src/hf_mem/gguf.py
@@ -310,7 +310,11 @@ def compute_gguf_kv_cache_size(
     embedding_length = kv_metadata["embedding_length"]
     context_length = kv_metadata["context_length"]
 
+    if any([not isinstance(v, int) for v in [block_count, head_count_kv, head_count, embedding_length, context_length]]):
+        raise RuntimeError("KV cache metadata fields must be integers for GGUF KV cache size estimation.")
+
     size_per_token = (2 * head_count_kv * (embedding_length // head_count))
+
     if kv_cache_dtype is not None:
         if kv_cache_dtype not in GGUFDtype.__members__:
             raise RuntimeError(f"--kv-cache-dtype={kv_cache_dtype} not recognized for GGUF KV cache size estimation. Valid options: {list(GGUFDtype.__members__.keys())}.")

--- a/src/hf_mem/gguf.py
+++ b/src/hf_mem/gguf.py
@@ -1,24 +1,27 @@
-from dataclasses import dataclass, asdict
-from typing import Dict, Optional, Any, Callable, Tuple
-from enum import IntEnum
 import asyncio
-import httpx
+import math
 import os
 import re
 import struct
-import math
-from hf_mem.types import get_safetensors_dtype_bytes
+from dataclasses import asdict, dataclass
+from enum import IntEnum
+from typing import Any, Callable, Dict, Optional, Tuple
+
+import httpx
+
 from hf_mem.metadata import DtypeMetadata
+from hf_mem.types import get_safetensors_dtype_bytes
 
 REQUEST_TIMEOUT = float(os.getenv("REQUEST_TIMEOUT", 30.0))
 SIZES = [1_000_000, 10_000_000, 50_000_000, 100_000_000]
 KV_CACHE_FIELD_ENDINGS = [
-    "block_count", 
-    "head_count_kv", 
+    "block_count",
+    "head_count_kv",
     "head_count",
     "embedding_length",
     "context_length",
 ]
+
 
 # --- GGUF Dtypes (weights) ---
 class GGUFDtype(IntEnum):
@@ -62,7 +65,8 @@ class GGUFDtype(IntEnum):
     # IQ4_NL_4_8 = 37
     # IQ4_NL_8_8 = 38
     MXFP4 = 39
-    COUNT = 40 # For exhaustivity, not used
+    COUNT = 40  # For exhaustivity, not used
+
 
 # Conversion .gguf weight dtype -> bits-per-weight
 GGUFDtypeBitsPerWeight: Dict[GGUFDtype, float] = {
@@ -105,56 +109,65 @@ GGUFDtypeBitsPerWeight: Dict[GGUFDtype, float] = {
 # --- Auxiliary read functions ---
 # Related to .gguf metadata dtypes, not weights dtypes
 def _read_string(raw_metadata: bytes, offset: int) -> tuple[str, int]:
-    length = struct.unpack("<Q", raw_metadata[offset:offset+8])[0]
+    length = struct.unpack("<Q", raw_metadata[offset : offset + 8])[0]
     offset += 8
-    key = raw_metadata[offset:offset+length].decode()
+    key = raw_metadata[offset : offset + length].decode()
     offset += length
     return key, offset
 
+
 def _read_uint8(raw_metadata: bytes, offset: int) -> tuple[int, int]:
-    value = struct.unpack("<B", raw_metadata[offset:offset+1])[0]
+    value = struct.unpack("<B", raw_metadata[offset : offset + 1])[0]
     offset += 1
     return value, offset
+
 
 def _read_int8(raw_metadata: bytes, offset: int) -> tuple[int, int]:
-    value = struct.unpack("<b", raw_metadata[offset:offset+1])[0]
+    value = struct.unpack("<b", raw_metadata[offset : offset + 1])[0]
     offset += 1
     return value, offset
+
 
 def _read_uint16(raw_metadata: bytes, offset: int) -> tuple[int, int]:
-    value = struct.unpack("<H", raw_metadata[offset:offset+2])[0]
+    value = struct.unpack("<H", raw_metadata[offset : offset + 2])[0]
     offset += 2
     return value, offset
+
 
 def _read_int16(raw_metadata: bytes, offset: int) -> tuple[int, int]:
-    value = struct.unpack("<h", raw_metadata[offset:offset+2])[0]
+    value = struct.unpack("<h", raw_metadata[offset : offset + 2])[0]
     offset += 2
     return value, offset
 
+
 def _read_uint32(raw_metadata: bytes, offset: int) -> tuple[int, int]:
-    value = struct.unpack("<I", raw_metadata[offset:offset+4])[0]
+    value = struct.unpack("<I", raw_metadata[offset : offset + 4])[0]
     offset += 4
     return value, offset
+
 
 def _read_int32(raw_metadata: bytes, offset: int) -> tuple[int, int]:
-    value = struct.unpack("<i", raw_metadata[offset:offset+4])[0]
+    value = struct.unpack("<i", raw_metadata[offset : offset + 4])[0]
     offset += 4
     return value, offset
+
 
 def _read_float32(raw_metadata: bytes, offset: int) -> tuple[float, int]:
-    value = struct.unpack("<f", raw_metadata[offset:offset+4])[0]
+    value = struct.unpack("<f", raw_metadata[offset : offset + 4])[0]
     offset += 4
     return value, offset
 
+
 def _read_bool(raw_metadata: bytes, offset: int) -> tuple[bool, int]:
-    value = struct.unpack("<?", raw_metadata[offset:offset+1])[0]
+    value = struct.unpack("<?", raw_metadata[offset : offset + 1])[0]
     offset += 1
     return value, offset
 
+
 def _read_array(raw_metadata: bytes, offset: int) -> tuple[list[Any], int]:
-    value_type = struct.unpack("<I", raw_metadata[offset:offset+4])[0]
+    value_type = struct.unpack("<I", raw_metadata[offset : offset + 4])[0]
     offset += 4
-    length = struct.unpack("<Q", raw_metadata[offset:offset+8])[0]
+    length = struct.unpack("<Q", raw_metadata[offset : offset + 8])[0]
     offset += 8
     value = []
     for i in range(length):
@@ -162,18 +175,21 @@ def _read_array(raw_metadata: bytes, offset: int) -> tuple[list[Any], int]:
         value.append(sub_value)
     return value, offset
 
+
 def _read_uint64(raw_metadata: bytes, offset: int) -> tuple[int, int]:
-    value = struct.unpack("<Q", raw_metadata[offset:offset+8])[0]
+    value = struct.unpack("<Q", raw_metadata[offset : offset + 8])[0]
     offset += 8
     return value, offset
+
 
 def _read_int64(raw_metadata: bytes, offset: int) -> tuple[int, int]:
-    value = struct.unpack("<q", raw_metadata[offset:offset+8])[0]
+    value = struct.unpack("<q", raw_metadata[offset : offset + 8])[0]
     offset += 8
     return value, offset
 
+
 def _read_float64(raw_metadata: bytes, offset: int) -> tuple[float, int]:
-    value = struct.unpack("<d", raw_metadata[offset:offset+8])[0]
+    value = struct.unpack("<d", raw_metadata[offset : offset + 8])[0]
     offset += 8
     return value, offset
 
@@ -194,6 +210,7 @@ class GGUFMetadataDtype(IntEnum):
     UINT64 = 10
     INT64 = 11
     FLOAT64 = 12
+
 
 Parsers: Dict[GGUFMetadataDtype, Callable] = {
     GGUFMetadataDtype.UINT8: _read_uint8,
@@ -218,12 +235,14 @@ class GGUFComponentMetadata:
     param_count: int
     bytes_count: int
 
+
 @dataclass
 class GGUFKVCacheInfo:
     max_model_len: int
     cache_size: int
     batch_size: int
     cache_dtype: Optional[str] = None
+
 
 @dataclass
 class GGUFMetadata:
@@ -236,50 +255,50 @@ class GGUFMetadata:
 def merge_shards(shard1: GGUFMetadata, shard2: GGUFMetadata) -> GGUFMetadata:
     merged_components = {}
     all_component_names = set(shard1.components.keys()) | set(shard2.components.keys())
-    
+
     for component_name in all_component_names:
         comp1 = shard1.components.get(component_name)
         comp2 = shard2.components.get(component_name)
-        
+
         if comp1 and comp2:
             # Both have it -> merge
             merged_dtypes = {}
             all_dtypes = set(comp1.dtypes.keys()) | set(comp2.dtypes.keys())
-            
+
             for dtype in all_dtypes:
                 dtype_meta1 = comp1.dtypes.get(dtype)
                 dtype_meta2 = comp2.dtypes.get(dtype)
-                
+
                 if dtype_meta1 and dtype_meta2:
                     # Both have it -> merge
                     merged_dtypes[dtype] = DtypeMetadata(
                         param_count=dtype_meta1.param_count + dtype_meta2.param_count,
-                        bytes_count=dtype_meta1.bytes_count + dtype_meta2.bytes_count
+                        bytes_count=dtype_meta1.bytes_count + dtype_meta2.bytes_count,
                     )
                 elif dtype_meta1:
                     merged_dtypes[dtype] = dtype_meta1
                 else:
                     merged_dtypes[dtype] = dtype_meta2
-            
+
             merged_components[component_name] = GGUFComponentMetadata(
                 dtypes=merged_dtypes,
                 param_count=comp1.param_count + comp2.param_count,
-                bytes_count=comp1.bytes_count + comp2.bytes_count
+                bytes_count=comp1.bytes_count + comp2.bytes_count,
             )
         elif comp1:
             merged_components[component_name] = comp1
         else:
             merged_components[component_name] = comp2
-    
+
     # KV-cache info should be the same for all shards, we use earlier ones since sometimes
     # cache metadata gets dropped after first shard
     kv_cache_info = shard1.kv_cache_info or shard2.kv_cache_info
-    
+
     return GGUFMetadata(
         components=merged_components,
         param_count=shard1.param_count + shard2.param_count,
         bytes_count=shard1.bytes_count + shard2.bytes_count,
-        kv_cache_info=kv_cache_info
+        kv_cache_info=kv_cache_info,
     )
 
 
@@ -290,7 +309,7 @@ def gguf_metadata_to_json(model_id: str, revision: str, metadata: GGUFMetadata) 
         k.name: v for k, v in out["components"]["Transformer"]["dtypes"].items()
     }
     out = {"model_id": model_id, "revision": revision, **out}
-    
+
     # If --experimental, move cache info out
     if out.get("kv_cache_info") is not None:
         out["max_model_len"] = out["kv_cache_info"]["max_model_len"]
@@ -301,50 +320,52 @@ def gguf_metadata_to_json(model_id: str, revision: str, metadata: GGUFMetadata) 
 
     return out
 
+
 def compute_gguf_kv_cache_size(
-        kv_metadata: dict, 
-        kv_cache_dtype: Optional[str] = "F16", 
-        batch_size: Optional[int] = 1
-        ) -> int:
+    kv_metadata: dict, kv_cache_dtype: Optional[str] = "F16", batch_size: Optional[int] = 1
+) -> int:
     block_count = kv_metadata["block_count"]
     head_count_kv = kv_metadata["head_count_kv"]
     head_count = kv_metadata["head_count"]
     embedding_length = kv_metadata["embedding_length"]
     context_length = kv_metadata["context_length"]
 
-    if any([not isinstance(v, int) for v in [block_count, head_count_kv, head_count, embedding_length, context_length]]):
+    if any(
+        [
+            not isinstance(v, int)
+            for v in [block_count, head_count_kv, head_count, embedding_length, context_length]
+        ]
+    ):
         raise RuntimeError("KV cache metadata fields must be integers for GGUF KV cache size estimation.")
 
-    size_per_token = (2 * head_count_kv * (embedding_length // head_count))
+    size_per_token = 2 * head_count_kv * (embedding_length // head_count)
 
     if kv_cache_dtype is not None:
         if kv_cache_dtype not in GGUFDtype.__members__:
-            raise RuntimeError(f"--kv-cache-dtype={kv_cache_dtype} not recognized for GGUF KV cache size estimation. Valid options: {list(GGUFDtype.__members__.keys())}.")
+            raise RuntimeError(
+                f"--kv-cache-dtype={kv_cache_dtype} not recognized for GGUF KV cache size estimation. Valid options: {list(GGUFDtype.__members__.keys())}."
+            )
         total_size = int(
-            block_count 
-            * size_per_token 
-            * context_length 
-            * batch_size 
-            * GGUFDtypeBitsPerWeight[GGUFDtype[kv_cache_dtype]] / 8.0
+            block_count
+            * size_per_token
+            * context_length
+            * batch_size
+            * GGUFDtypeBitsPerWeight[GGUFDtype[kv_cache_dtype]]
+            / 8.0
         )
     else:
         # Default to F16 size
-        total_size = int(
-            block_count 
-            * size_per_token 
-            * context_length 
-            * batch_size 
-            * 2
-        )
+        total_size = int(block_count * size_per_token * context_length * batch_size * 2)
     return total_size
 
+
 def parse_gguf_metadata(
-        raw_metadata: bytes,
-        experimental: bool = False,
-        max_model_len: Optional[int] = None,
-        kv_cache_dtype: Optional[str] = "F16",
-        batch_size: int = 1
-        ) -> GGUFMetadata:
+    raw_metadata: bytes,
+    experimental: bool = False,
+    max_model_len: Optional[int] = None,
+    kv_cache_dtype: Optional[str] = "F16",
+    batch_size: int = 1,
+) -> GGUFMetadata:
     # Header
     magic = raw_metadata[:4].decode("ascii")
     version = struct.unpack("<I", raw_metadata[4:8])[0]
@@ -356,11 +377,11 @@ def parse_gguf_metadata(
     # KV Cache Metadata
     for i in range(metadata_kv_count):
         key, offset = _read_string(raw_metadata, offset)
-        value_type = version = struct.unpack("<I", raw_metadata[offset:offset+4])[0]
+        value_type = version = struct.unpack("<I", raw_metadata[offset : offset + 4])[0]
         offset += 4
         value, offset = Parsers[value_type](raw_metadata, offset)
         kv_metadata[key] = value
-    
+
     kv_cache_info = None
     if experimental:
         # Extract and rename KV only necessary cache fields
@@ -372,7 +393,7 @@ def parse_gguf_metadata(
         }
 
         # Replace with optional fields
-        if max_model_len is not None: 
+        if max_model_len is not None:
             kv_cache_dict["context_length"] = max_model_len
         if kv_cache_dtype is not None:
             kv_cache_dict["kv_dtype"] = kv_cache_dtype
@@ -384,21 +405,16 @@ def parse_gguf_metadata(
             raise RuntimeError(
                 f"Incomplete KV cache metadata for size estimation. Missing fields: {missing_fields}"
             )
-        
-        kv_size = compute_gguf_kv_cache_size(
-            kv_cache_dict, 
-            kv_cache_dtype,
-            kv_cache_dict.get("batch_size", 1)
-        )
-        
+
+        kv_size = compute_gguf_kv_cache_size(kv_cache_dict, kv_cache_dtype, kv_cache_dict.get("batch_size", 1))
+
         kv_cache_info = GGUFKVCacheInfo(
             max_model_len=kv_cache_dict["context_length"],
             cache_size=kv_size,
             batch_size=kv_cache_dict["batch_size"],
             cache_dtype=kv_cache_dtype if kv_cache_dtype is not None else "F16",
         )
-        
-    
+
     # Tensor info
     component = GGUFComponentMetadata(dtypes={}, param_count=0, bytes_count=0)
     for i in range(tensor_count):
@@ -444,13 +460,13 @@ async def fetch_gguf_with_semaphore(
     max_model_len: Optional[int] = None,
     kv_cache_dtype: Optional[str] = "F16",
     batch_size: int = 1,
-    headers: Optional[Dict[str, str]] = None
+    headers: Optional[Dict[str, str]] = None,
 ) -> Tuple[str, "GGUFMetadata", Optional[re.Match]]:
     async with semaphore:
         f_url = f"https://huggingface.co/{model_id}/resolve/{revision}/{str(path)}"
         metadata = await fetch_gguf_metadata(
-            client=client, 
-            url=f_url, 
+            client=client,
+            url=f_url,
             experimental=parse_kv_cache,
             max_model_len=max_model_len,
             kv_cache_dtype=kv_cache_dtype,
@@ -461,16 +477,16 @@ async def fetch_gguf_with_semaphore(
 
 
 async def fetch_gguf_metadata(
-    client: httpx.AsyncClient, 
-    url: str, 
+    client: httpx.AsyncClient,
+    url: str,
     experimental: bool = False,
     max_model_len: Optional[int] = None,
     kv_cache_dtype: Optional[str] = "F16",
     batch_size: int = 1,
-    headers: Optional[Dict[str, str]] = None
+    headers: Optional[Dict[str, str]] = None,
 ) -> GGUFMetadata:
     for size in SIZES:
-        try: 
+        try:
             if kv_cache_dtype is not None and kv_cache_dtype == "auto":
                 kv_cache_dtype = "F16"
             request_headers = {"Range": f"bytes=0-{size}", **(headers or {})}
@@ -479,15 +495,18 @@ async def fetch_gguf_metadata(
 
             raw_metadata = response.read()
             processed_metadata = parse_gguf_metadata(
-                raw_metadata = raw_metadata, 
-                experimental = experimental, 
-                max_model_len = max_model_len, 
-                kv_cache_dtype = kv_cache_dtype, 
-                batch_size = batch_size)
-            
+                raw_metadata=raw_metadata,
+                experimental=experimental,
+                max_model_len=max_model_len,
+                kv_cache_dtype=kv_cache_dtype,
+                batch_size=batch_size,
+            )
+
             return processed_metadata
-        
+
         except (struct.error, UnicodeDecodeError):
             if size == SIZES[-1]:
-                raise RuntimeError(f"Failed to parse GGUF metadata from {url}, metadata larger than {size/1_000_000:.2f} MB.")
+                raise RuntimeError(
+                    f"Failed to parse GGUF metadata from {url}, metadata larger than {size / 1_000_000:.2f} MB."
+                )
             continue

--- a/src/hf_mem/gguf.py
+++ b/src/hf_mem/gguf.py
@@ -9,8 +9,8 @@ from typing import Any, Callable, Dict, Optional, Tuple
 
 import httpx
 
+from hf_mem import __version__
 from hf_mem.metadata import DtypeMetadata
-from hf_mem.types import get_safetensors_dtype_bytes
 
 REQUEST_TIMEOUT = float(os.getenv("REQUEST_TIMEOUT", 30.0))
 SIZES = [1_000_000, 10_000_000, 50_000_000, 100_000_000]
@@ -304,6 +304,7 @@ def merge_shards(shard1: GGUFMetadata, shard2: GGUFMetadata) -> GGUFMetadata:
 
 def gguf_metadata_to_json(model_id: str, revision: str, metadata: GGUFMetadata) -> Dict[str, Any]:
     out = asdict(metadata)
+    out = {"version": __version__, **out}
     # Convert dtypes enum keys to string names
     out["components"]["Transformer"]["dtypes"] = {
         k.name: v for k, v in out["components"]["Transformer"]["dtypes"].items()

--- a/src/hf_mem/print.py
+++ b/src/hf_mem/print.py
@@ -116,7 +116,7 @@ def _bytes_to_gib(nbytes: int) -> float:
 def print_report(
     model_id: str,
     revision: str,
-    metadata: SafetensorsMetadata,
+    metadata: SafetensorsMetadata | GGUFMetadata,
     cache: Optional[Dict[str, Any]] = None,
     ignore_table_width: bool = False,
 ) -> None:
@@ -222,14 +222,20 @@ def print_report(
             ]
         )
         for idx, (dtype, dtype_metadata) in enumerate(value.dtypes.items()):
-            gib_text = (
-                f"{_bytes_to_gib(dtype_metadata.bytes_count):.2f} / {_bytes_to_gib(combined_total):.2f} GiB"
-            )
-            _print_row(
-                dtype.upper() + " " * (max_length - len(dtype)),
-                gib_text,
-                data_col_width,
-            )
+
+            gib_text = f"{_bytes_to_gib(dtype_metadata.bytes_count):.2f} / {_bytes_to_gib(combined_total):.2f} GiB"
+            if isinstance(metadata, GGUFMetadata):
+                _print_row(
+                    dtype.name.upper() + " " * (max_length - len(dtype.name)),
+                    gib_text,
+                    data_col_width,
+                )
+            else:                
+                _print_row(
+                    dtype.upper() + " " * (max_length - len(dtype)),
+                    gib_text,
+                    data_col_width,
+                )
 
             bar = _make_bar(
                 _bytes_to_gib(dtype_metadata.bytes_count),
@@ -276,24 +282,41 @@ def print_report_for_gguf(
     gguf_files: Dict[str, GGUFMetadata],
     ignore_table_width: bool = False,
 ) -> None:
-    
     centered_rows = [
         "INFERENCE MEMORY ESTIMATE FOR",
         f"https://hf.co/{model_id} @ {revision}",
     ]
+    first_cache = list(gguf_files.values())[0].kv_cache_info
+    if first_cache is not None:
+        centered_rows.append(f"w/ max-model-len={first_cache.max_model_len}, batch-size={first_cache.batch_size}")
+    
     for filename, gguf_metadata in gguf_files.items():
         centered_rows.append(filename)
 
-        # Adding also the KV lines to compute curren_len since they are most likely the longest
+        # Adding model names lines to compute current_len
+        transformer = gguf_metadata.components.get("Transformer")
+        if transformer:
+            for _, dtype_metadata in transformer.dtypes.items():
+                if gguf_metadata.kv_cache_info is not None:
+                    total = dtype_metadata.bytes_count + gguf_metadata.kv_cache_info.cache_size
+                    centered_rows.append(
+                        f"{filename} | {_bytes_to_gib(total):.2f} GiB ({_format_short_number(dtype_metadata.param_count)} PARAMS + KV CACHE)"
+                    )
+                else:
+                    centered_rows.append(
+                        f"{filename} | {_bytes_to_gib(dtype_metadata.bytes_count):.2f} GiB ({_format_short_number(dtype_metadata.param_count)} PARAMS)"
+                    )
+
+        # Adding also the KV lines to compute current_len
         if gguf_metadata.kv_cache_info is not None:
-            cache_size = _bytes_to_gb(gguf_metadata.kv_cache_info.cache_size)
+            cache_size = _bytes_to_gib(gguf_metadata.kv_cache_info.cache_size)
             name_text = f"KV CACHE ({gguf_metadata.kv_cache_info.cache_dtype})"
             max_model_len = gguf_metadata.kv_cache_info.max_model_len
             batch_size = gguf_metadata.kv_cache_info.batch_size
-            total_gbs = _bytes_to_gb(gguf_metadata.bytes_count + gguf_metadata.kv_cache_info.cache_size)
-            gb_text = f"{cache_size:.2f} / {total_gbs:.2f} GB"
+            total_gibs = _bytes_to_gib(gguf_metadata.bytes_count + gguf_metadata.kv_cache_info.cache_size)
+            gib_text = f"{cache_size:.2f} / {total_gibs:.2f} GiB"
             kv_extra_info = f"(w/ max-model-len={max_model_len}, batch-size={batch_size})"
-            centered_rows.append(name_text + gb_text + kv_extra_info)
+            centered_rows.append(name_text + gib_text + kv_extra_info)
             
     max_centered_len = max(len(r) for r in centered_rows)
     
@@ -302,94 +325,51 @@ def print_report_for_gguf(
             f"Given that the provided `--model-id {model_id}` (with `--revision {revision}`) is longer than {MAX_DATA_LEN} characters, the table width will be expanded to fit the provided values within their row, but it might lead to unexpected table views. If you'd like to ignore the limit, then provide the `--ignore-table-width` flag to ignore the {MAX_DATA_LEN} width limit, to simply accommodate to whatever the longest text length is."
         )
     current_len = min(max_centered_len, MAX_DATA_LEN) if ignore_table_width is False else max_centered_len
-    data_col_width = current_len + 2 * BORDERS_AND_PADDING - MAX_NAME_LEN - 5
 
     # Header
     _print_header(current_len)
     _print_centered("INFERENCE MEMORY ESTIMATE FOR", current_len)
     _print_centered(f"https://hf.co/{model_id} @ {revision}", current_len)
-    _print_divider(data_col_width + 1, "mid")
+    if first_cache is not None:
+        _print_centered(
+            f"w/ max-model-len={first_cache.max_model_len}, batch-size={first_cache.batch_size}",
+            current_len,
+        )
+    max_name_length = min(
+        max(
+            [
+                len(filename)
+                for filename in gguf_files.keys()
+            ]
+        ),
+        MAX_DATA_LEN
+    )
+    data_col_width = current_len + 2 * BORDERS_AND_PADDING - max_name_length - 5
+    _print_divider(data_col_width + 1, "top", name_len=max_name_length)
 
     for i, (filename, gguf_metadata) in enumerate(gguf_files.items()):
-        # Centered name of the file
-        _print_centered(filename, current_len)
-        _print_divider(data_col_width + 1, "top")
-
-        # Total memory requirements row
-        total_gibs = _bytes_to_gib(gguf_metadata.bytes_count)
-        total_text = f"{total_gibs:.2f} GiB ({_format_short_number(gguf_metadata.param_count)} PARAMS)"
-        total_bar = _make_bar(gguf_metadata.bytes_count, gguf_metadata.bytes_count, data_col_width)
-
-        # If kv cache -> Add extra GBs + suffix on first line 
-        if gguf_metadata.kv_cache_info is not None:
-            total_gbs += _bytes_to_gb(gguf_metadata.kv_cache_info.cache_size)
-            total_text = f"{total_gbs:.2f} GB ({_format_short_number(gguf_metadata.param_count)} PARAMS + KV CACHE)"
-        
-        _print_row("TOTAL MEMORY", total_text, data_col_width)
-        _print_row("REQUIREMENTS", total_bar, data_col_width)
-
         transformer = gguf_metadata.components.get("Transformer")
         if transformer and transformer.dtypes:
-            _print_divider(data_col_width + 1)
-            max_length = max(
-                [
-                    len(f"{_format_short_number(dtype_metadata.param_count)} PARAMS")
-                    for _, dtype_metadata in transformer.dtypes.items()
-                ]
-            )
-
-            for idx, (dtype, dtype_metadata) in enumerate(transformer.dtypes.items()):
-                
-                # Dtypes rows
-                gib_text = f"{_bytes_to_gib(dtype_metadata.bytes_count):.2f} / {total_gibs:.2f} GiB"
+            if gguf_metadata.kv_cache_info is not None:
+                # Print NAME | GiBs ( PARAMS + KV CACHE) rows
+                gib_text = f"{_bytes_to_gib(transformer.bytes_count + gguf_metadata.kv_cache_info.cache_size):.2f} GiB ({_format_short_number(transformer.param_count)} PARAMS + KV CACHE)"
                 _print_row(
-                    dtype.name.upper() + " " * (max_length - len(dtype.name)),
+                    filename + " " * (max_name_length - len(filename)),
                     gib_text,
                     data_col_width,
+                    name_len=max_name_length,
                 )
-
-                bar = _make_bar(
-                    _bytes_to_gib(dtype_metadata.bytes_count),
-                    total_gibs,
-                    data_col_width,
-                )
+            else:
+                # Print NAME | GiBs ( PARAMS ) rows
+                gib_text = f"{_bytes_to_gib(transformer.bytes_count):.2f} GiB ({_format_short_number(transformer.param_count)} PARAMS)"
                 _print_row(
-                    f"{_format_short_number(dtype_metadata.param_count)} PARAMS",
-                    bar,
+                    filename + " " * (max_name_length - len(filename)),
+                    gib_text,
                     data_col_width,
-                )
-
-                if idx < len(transformer.dtypes) - 1:
-                    _print_divider(data_col_width + 1)
-
-            # Print kv-cache info (1 per .gguf file)
-            # Same size for all but diferent % of total size between models.
-            if gguf_metadata.kv_cache_info is not None:
-                _print_divider(data_col_width + 1)
-                cache_size = _bytes_to_gb(gguf_metadata.kv_cache_info.cache_size)
-                name_text = f"KV CACHE ({gguf_metadata.kv_cache_info.cache_dtype})"
-                max_model_len = gguf_metadata.kv_cache_info.max_model_len
-                batch_size = gguf_metadata.kv_cache_info.batch_size
-                gb_text = f"{cache_size:.2f} / {total_gbs:.2f} GB"
-                kv_extra_info = f"(w/ max-model-len={max_model_len}, batch-size={batch_size})"
-                _print_row(
-                    name_text + " " * (max_length - len(name_text)),
-                    gb_text + " " + kv_extra_info,
-                    data_col_width,
-                )
-
-                bar = _make_bar(
-                    cache_size,
-                    total_gbs,
-                    data_col_width,
-                )
-                _print_row(
-                    f"{gguf_metadata.kv_cache_info.max_model_len * gguf_metadata.kv_cache_info.batch_size} TOKENS",
-                    bar,
-                    data_col_width,
+                    name_len=max_name_length,
                 )
 
         if i < len(gguf_files) - 1:
-            _print_divider(data_col_width + 1, "bottom-continue")
+            _print_divider(data_col_width + 1, name_len=max_name_length)
         else:
-            _print_divider(data_col_width + 1, "bottom")
+            _print_divider(data_col_width + 1, "bottom", name_len=max_name_length)

--- a/src/hf_mem/print.py
+++ b/src/hf_mem/print.py
@@ -1,9 +1,9 @@
-import re
 import warnings
 from typing import Any, Dict, Literal, Optional
 
 from hf_mem import __version__
 from hf_mem.metadata import SafetensorsMetadata
+from hf_mem.gguf import GGUFMetadata
 
 MIN_NAME_LEN = 5
 MAX_NAME_LEN = 14
@@ -30,8 +30,8 @@ def _print_with_color(content: str) -> None:
     print(f"\x1b[38;2;244;183;63m{content}\x1b[0m")
 
 
-def _print_header(current_len: int, name_len: int = MAX_NAME_LEN) -> None:
-    length = current_len + name_len + BORDERS_AND_PADDING
+def _print_header(current_len: int) -> None:
+    length = current_len + 2 * BORDERS_AND_PADDING + 2
     top = BOX["tl"] + (BOX["tsep"] * (length - 2)) + BOX["tr"]
     _print_with_color(top)
 
@@ -39,9 +39,8 @@ def _print_header(current_len: int, name_len: int = MAX_NAME_LEN) -> None:
     _print_with_color(bottom)
 
 
-def _print_centered(text: str, current_len: int, name_len: int = MAX_NAME_LEN) -> None:
-    max_len = current_len + name_len - BORDERS_AND_PADDING
-    total_width = max_len + 12
+def _print_centered(text: str, current_len: int) -> None:
+    total_width = current_len + 2 * BORDERS_AND_PADDING
     text_len = len(text)
     pad_left = (total_width - text_len) // 2
     pad_right = total_width - text_len - pad_left
@@ -50,7 +49,7 @@ def _print_centered(text: str, current_len: int, name_len: int = MAX_NAME_LEN) -
 
 def _print_divider(
     current_len: int,
-    side: Optional[Literal["top", "top-continue", "bottom", "bottom-continue"]] = None,
+    side: Optional[Literal["top", "top-continue", "mid", "bottom", "bottom-continue"]] = None,
     name_len: int = MAX_NAME_LEN,
 ) -> None:
     match side:
@@ -62,6 +61,8 @@ def _print_divider(
             left, mid, right = BOX["bl"], BOX["bsep"], BOX["br"]
         case "bottom-continue":
             left, mid, right = BOX["lm"], BOX["bsep"], BOX["rm"]
+        case "mid":
+            left, mid, right = BOX["lm"], BOX["ht"], BOX["rm"]
         case _:
             left, mid, right = BOX["lm"], BOX["mm"], BOX["rm"]
 
@@ -76,12 +77,12 @@ def _print_divider(
     _print_with_color(line)
 
 
-def _format_name(name: str, name_len: int = MAX_NAME_LEN) -> str:
+def _format_name(name: str, max_len: int = MAX_NAME_LEN) -> str:
     if len(name) < MIN_NAME_LEN:
         return f"{name:<{MIN_NAME_LEN}}"
-    if len(name) > name_len:
-        return name[: name_len - 3] + "..."
-    return f"{name:<{name_len}}"
+    if len(name) > max_len:
+        return name[: max_len - 3] + "..."
+    return f"{name:<{max_len}}"
 
 
 def _print_row(name: str, text: str, current_len: int, name_len: int = MAX_NAME_LEN) -> None:
@@ -267,75 +268,84 @@ def print_report(
         )
 
     _print_divider(data_col_width + 1, "bottom")
-    _print_divider(current_len + 1, "bottom")
-
-
-def _group_gguf_files(gguf_files: Dict[str, int]) -> Dict[str, int]:
-    """Group sharded GGUF files by model variant and sum their sizes.
-
-    Files like 'BF16/model-00001-of-00010.gguf' are grouped together.
-    For example, 'BF16/model-00001-of-00010.gguf' and 'BF16/model-00002-of-00010.gguf'
-    are grouped under 'BF16/model.gguf'.
-    Single files like 'model-Q4_K_M.gguf' remain as-is.
-    Supports various shard formats: -1-of-2.gguf, -001-of-002.gguf, -00001-of-00010.gguf, etc.
-    """
-    grouped: Dict[str, int] = {}
-    shard_pattern = re.compile(r"-\d+-of-\d+\.gguf$")
-
-    for path, size in gguf_files.items():
-        if shard_pattern.search(path):
-            base = shard_pattern.sub(".gguf", path)
-            grouped[base] = grouped.get(base, 0) + size
-        else:
-            grouped[path] = size
-
-    return grouped
 
 
 def print_report_for_gguf(
     model_id: str,
     revision: str,
-    gguf_files: Dict[str, int],
+    gguf_files: Dict[str, GGUFMetadata],
     ignore_table_width: bool = False,
 ) -> None:
-    """Print VRAM report for GGUF models.
-
-    Args:
-        model_id: HuggingFace model ID
-        revision: Model revision
-        gguf_files: Dict mapping filename to file size in bytes
-        ignore_table_width: Whether to ignore max table width
-    """
-    grouped_files = _group_gguf_files(gguf_files)
-
-    max_name_len = max(len(filename) for filename in grouped_files.keys())
-
-    rows = [
+    
+    centered_rows = [
         "INFERENCE MEMORY ESTIMATE FOR",
         f"https://hf.co/{model_id} @ {revision}",
     ]
+    for filename in gguf_files.keys():
+        centered_rows.append(filename)
 
-    max_len = 0
-    for r in rows:
-        max_len = max(max_len, len(str(r)))
+    max_centered_len = max(len(r) for r in centered_rows)
 
-    if max_len > MAX_DATA_LEN and ignore_table_width is False:
+    if max_centered_len > MAX_DATA_LEN and ignore_table_width is False:
         warnings.warn(
             f"Given that the provided `--model-id {model_id}` (with `--revision {revision}`) is longer than {MAX_DATA_LEN} characters, the table width will be expanded to fit the provided values within their row, but it might lead to unexpected table views. If you'd like to ignore the limit, then provide the `--ignore-table-width` flag to ignore the {MAX_DATA_LEN} width limit, to simply accommodate to whatever the longest text length is."
         )
+    current_len = min(max_centered_len, MAX_DATA_LEN) if ignore_table_width is False else max_centered_len
+    data_col_width = current_len + 2 * BORDERS_AND_PADDING - MAX_NAME_LEN - 5
 
-    current_len = min(max_len, MAX_DATA_LEN) if ignore_table_width is False else max_len
+    # Header
+    _print_header(current_len)
+    _print_centered("INFERENCE MEMORY ESTIMATE FOR", current_len)
+    _print_centered(f"https://hf.co/{model_id} @ {revision}", current_len)
+    _print_divider(data_col_width + 1, "mid")
 
-    _print_header(current_len, max_name_len)
-    _print_centered("INFERENCE MEMORY ESTIMATE FOR", current_len, max_name_len)
-    _print_centered(f"https://hf.co/{model_id} @ {revision}", current_len, max_name_len)
-    _print_divider(current_len + 1, "top", max_name_len)
+    for i, (filename, gguf_metadata) in enumerate(gguf_files.items()):
+        # Centered name of the file
+        _print_centered(filename, current_len)
+        _print_divider(data_col_width + 1, "top")
 
-    for i, (filename, size_bytes) in enumerate(grouped_files.items()):
-        file_gb = _bytes_to_gb(size_bytes, use_decimal=True)
-        _print_row(filename, f"{file_gb:.2f} GB", current_len, max_name_len)
+        # Total memory requirements row
+        total_gibs = _bytes_to_gib(gguf_metadata.bytes_count)
+        total_text = f"{total_gibs:.2f} GiB ({_format_short_number(gguf_metadata.param_count)} PARAMS)"
+        total_bar = _make_bar(gguf_metadata.bytes_count, gguf_metadata.bytes_count, data_col_width)
+        _print_row("TOTAL MEMORY", total_text, data_col_width)
+        _print_row("REQUIREMENTS", total_bar, data_col_width)
 
-        if i < len(grouped_files) - 1:
-            _print_divider(current_len + 1, name_len=max_name_len)
+        transformer = gguf_metadata.components.get("Transformer")
+        if transformer and transformer.dtypes:
+            _print_divider(data_col_width + 1)
+            max_length = max(
+                [
+                    len(f"{_format_short_number(dtype_metadata.param_count)} PARAMS")
+                    for _, dtype_metadata in transformer.dtypes.items()
+                ]
+            )
 
-    _print_divider(current_len + 1, "bottom", max_name_len)
+            for idx, (dtype, dtype_metadata) in enumerate(transformer.dtypes.items()):
+                
+                # Dtypes rows
+                gib_text = f"{_bytes_to_gib(dtype_metadata.bytes_count):.2f} / {total_gibs:.2f} GiB"
+                _print_row(
+                    dtype.name.upper() + " " * (max_length - len(dtype.name)),
+                    gib_text,
+                    data_col_width,
+                )
+
+                bar = _make_bar(
+                    _bytes_to_gib(dtype_metadata.bytes_count),
+                    total_gibs,
+                    data_col_width,
+                )
+                _print_row(
+                    f"{_format_short_number(dtype_metadata.param_count)} PARAMS",
+                    bar,
+                    data_col_width,
+                )
+
+                if idx < len(transformer.dtypes) - 1:
+                    _print_divider(data_col_width + 1)
+
+        if i < len(gguf_files) - 1:
+            _print_divider(data_col_width + 1, "bottom-continue")
+        else:
+            _print_divider(data_col_width + 1, "bottom")

--- a/src/hf_mem/print.py
+++ b/src/hf_mem/print.py
@@ -281,11 +281,22 @@ def print_report_for_gguf(
         "INFERENCE MEMORY ESTIMATE FOR",
         f"https://hf.co/{model_id} @ {revision}",
     ]
-    for filename in gguf_files.keys():
+    for filename, gguf_metadata in gguf_files.items():
         centered_rows.append(filename)
 
+        # Adding also the KV lines to compute curren_len since they are most likely the longest
+        if gguf_metadata.kv_cache_info is not None:
+            cache_size = _bytes_to_gb(gguf_metadata.kv_cache_info.cache_size)
+            name_text = f"KV CACHE ({gguf_metadata.kv_cache_info.cache_dtype})"
+            max_model_len = gguf_metadata.kv_cache_info.max_model_len
+            batch_size = gguf_metadata.kv_cache_info.batch_size
+            total_gbs = _bytes_to_gb(gguf_metadata.bytes_count + gguf_metadata.kv_cache_info.cache_size)
+            gb_text = f"{cache_size:.2f} / {total_gbs:.2f} GB"
+            kv_extra_info = f"(w/ max-model-len={max_model_len}, batch-size={batch_size})"
+            centered_rows.append(name_text + gb_text + kv_extra_info)
+            
     max_centered_len = max(len(r) for r in centered_rows)
-
+    
     if max_centered_len > MAX_DATA_LEN and ignore_table_width is False:
         warnings.warn(
             f"Given that the provided `--model-id {model_id}` (with `--revision {revision}`) is longer than {MAX_DATA_LEN} characters, the table width will be expanded to fit the provided values within their row, but it might lead to unexpected table views. If you'd like to ignore the limit, then provide the `--ignore-table-width` flag to ignore the {MAX_DATA_LEN} width limit, to simply accommodate to whatever the longest text length is."
@@ -308,6 +319,12 @@ def print_report_for_gguf(
         total_gibs = _bytes_to_gib(gguf_metadata.bytes_count)
         total_text = f"{total_gibs:.2f} GiB ({_format_short_number(gguf_metadata.param_count)} PARAMS)"
         total_bar = _make_bar(gguf_metadata.bytes_count, gguf_metadata.bytes_count, data_col_width)
+
+        # If kv cache -> Add extra GBs + suffix on first line 
+        if gguf_metadata.kv_cache_info is not None:
+            total_gbs += _bytes_to_gb(gguf_metadata.kv_cache_info.cache_size)
+            total_text = f"{total_gbs:.2f} GB ({_format_short_number(gguf_metadata.param_count)} PARAMS + KV CACHE)"
+        
         _print_row("TOTAL MEMORY", total_text, data_col_width)
         _print_row("REQUIREMENTS", total_bar, data_col_width)
 
@@ -344,6 +361,33 @@ def print_report_for_gguf(
 
                 if idx < len(transformer.dtypes) - 1:
                     _print_divider(data_col_width + 1)
+
+            # Print kv-cache info (1 per .gguf file)
+            # Same size for all but diferent % of total size between models.
+            if gguf_metadata.kv_cache_info is not None:
+                _print_divider(data_col_width + 1)
+                cache_size = _bytes_to_gb(gguf_metadata.kv_cache_info.cache_size)
+                name_text = f"KV CACHE ({gguf_metadata.kv_cache_info.cache_dtype})"
+                max_model_len = gguf_metadata.kv_cache_info.max_model_len
+                batch_size = gguf_metadata.kv_cache_info.batch_size
+                gb_text = f"{cache_size:.2f} / {total_gbs:.2f} GB"
+                kv_extra_info = f"(w/ max-model-len={max_model_len}, batch-size={batch_size})"
+                _print_row(
+                    name_text + " " * (max_length - len(name_text)),
+                    gb_text + " " + kv_extra_info,
+                    data_col_width,
+                )
+
+                bar = _make_bar(
+                    cache_size,
+                    total_gbs,
+                    data_col_width,
+                )
+                _print_row(
+                    f"{gguf_metadata.kv_cache_info.max_model_len * gguf_metadata.kv_cache_info.batch_size} TOKENS",
+                    bar,
+                    data_col_width,
+                )
 
         if i < len(gguf_files) - 1:
             _print_divider(data_col_width + 1, "bottom-continue")

--- a/src/hf_mem/print.py
+++ b/src/hf_mem/print.py
@@ -1,3 +1,4 @@
+import re
 import warnings
 from typing import Any, Dict, Literal, Optional
 
@@ -265,3 +266,124 @@ def print_report(
         )
 
     _print_divider(data_col_width + 1, "bottom")
+    _print_divider(current_len + 1, "bottom")
+
+
+def _print_header_gguf(current_len: int, name_len: int) -> None:
+    length = current_len + name_len + BORDERS_AND_PADDING
+    top = BOX["tl"] + (BOX["tsep"] * (length - 2)) + BOX["tr"]
+    _print_with_color(top)
+
+    bottom = BOX["lm"] + (BOX["bsep"] * (length - 2)) + BOX["rm"]
+    _print_with_color(bottom)
+
+
+def _print_centered_gguf(text: str, current_len: int, name_len: int) -> None:
+    max_len = current_len + name_len - BORDERS_AND_PADDING
+    total_width = max_len + 12
+    text_len = len(text)
+    pad_left = (total_width - text_len) // 2
+    pad_right = total_width - text_len - pad_left
+    _print_with_color(f"{BOX['vt']}{' ' * pad_left}{text}{' ' * pad_right}{BOX['vt']}")
+
+
+def _print_divider_gguf(
+    current_len: int,
+    name_len: int,
+    side: Optional[Literal["top", "top-continue", "bottom", "bottom-continue"]] = None,
+) -> None:
+    match side:
+        case "top":
+            left, mid, right = BOX["lm"], BOX["tsep"], BOX["rm"]
+        case "top-continue":
+            left, mid, right = BOX["lm"], BOX["bsep"], BOX["rm"]
+        case "bottom":
+            left, mid, right = BOX["bl"], BOX["bsep"], BOX["br"]
+        case "bottom-continue":
+            left, mid, right = BOX["lm"], BOX["bsep"], BOX["rm"]
+        case _:
+            left, mid, right = BOX["lm"], BOX["mm"], BOX["rm"]
+
+    name_col_inner = name_len + 2
+    data_col_inner = current_len + 1
+
+    line = left
+    line += BOX["ht"] * name_col_inner
+    line += mid
+    line += BOX["ht"] * data_col_inner
+    line += right
+    _print_with_color(line)
+
+
+def _print_row_gguf(name: str, text: str, current_len: int, name_len: int) -> None:
+    name_fmt = f"{name:<{name_len}}"
+    data_fmt = f"{str(text):<{current_len}}"
+    _print_with_color(f"{BOX['vt']} {name_fmt} {BOX['vt']} {data_fmt} {BOX['vt']}")
+
+
+def _group_gguf_files(gguf_files: Dict[str, int]) -> Dict[str, int]:
+    """Group sharded GGUF files by model variant and sum their sizes.
+
+    Files like 'BF16/model-00001-of-00010.gguf' are grouped together.
+    Single files like 'model-Q4_K_M.gguf' remain as-is.
+    """
+    grouped: Dict[str, int] = {}
+    shard_pattern = re.compile(r"-\d{5}-of-\d{5}\.gguf$")
+
+    for path, size in gguf_files.items():
+        if shard_pattern.search(path):
+            base = shard_pattern.sub(".gguf", path)
+            grouped[base] = grouped.get(base, 0) + size
+        else:
+            grouped[path] = size
+
+    return grouped
+
+
+def print_report_for_gguf(
+    model_id: str,
+    revision: str,
+    gguf_files: Dict[str, int],
+    ignore_table_width: bool = False,
+) -> None:
+    """Print VRAM report for GGUF models.
+
+    Args:
+        model_id: HuggingFace model ID
+        revision: Model revision
+        gguf_files: Dict mapping filename to file size in bytes
+        ignore_table_width: Whether to ignore max table width
+    """
+    grouped_files = _group_gguf_files(gguf_files)
+
+    max_name_len = max(len(filename) for filename in grouped_files.keys())
+
+    rows = [
+        "INFERENCE MEMORY ESTIMATE FOR",
+        f"https://hf.co/{model_id} @ {revision}",
+    ]
+
+    max_len = 0
+    for r in rows:
+        max_len = max(max_len, len(str(r)))
+
+    if max_len > MAX_DATA_LEN and ignore_table_width is False:
+        warnings.warn(
+            f"Given that the provided `--model-id {model_id}` (with `--revision {revision}`) is longer than {MAX_DATA_LEN} characters, the table width will be expanded to fit the provided values within their row, but it might lead to unexpected table views. If you'd like to ignore the limit, then provide the `--ignore-table-width` flag to ignore the {MAX_DATA_LEN} width limit, to simply accommodate to whatever the longest text length is."
+        )
+
+    current_len = min(max_len, MAX_DATA_LEN) if ignore_table_width is False else max_len
+
+    _print_header_gguf(current_len, max_name_len)
+    _print_centered_gguf("INFERENCE MEMORY ESTIMATE FOR", current_len, max_name_len)
+    _print_centered_gguf(f"https://hf.co/{model_id} @ {revision}", current_len, max_name_len)
+    _print_divider_gguf(current_len + 1, max_name_len, "top")
+
+    for i, (filename, size_bytes) in enumerate(grouped_files.items()):
+        file_gb = _bytes_to_gib(size_bytes)
+        _print_row_gguf(filename, f"{file_gb:.2f} GB", current_len, max_name_len)
+
+        if i < len(grouped_files) - 1:
+            _print_divider_gguf(current_len + 1, max_name_len)
+
+    _print_divider_gguf(current_len + 1, max_name_len, "bottom")

--- a/src/hf_mem/print.py
+++ b/src/hf_mem/print.py
@@ -1,10 +1,10 @@
-from functools import cache
 import warnings
+from functools import cache
 from typing import Any, Dict, Literal, Optional
 
 from hf_mem import __version__
-from hf_mem.metadata import SafetensorsMetadata
 from hf_mem.gguf import GGUFMetadata
+from hf_mem.metadata import SafetensorsMetadata
 
 MIN_NAME_LEN = 5
 MAX_NAME_LEN = 14
@@ -223,15 +223,16 @@ def print_report(
             ]
         )
         for idx, (dtype, dtype_metadata) in enumerate(value.dtypes.items()):
-
-            gib_text = f"{_bytes_to_gib(dtype_metadata.bytes_count):.2f} / {_bytes_to_gib(combined_total):.2f} GiB"
+            gib_text = (
+                f"{_bytes_to_gib(dtype_metadata.bytes_count):.2f} / {_bytes_to_gib(combined_total):.2f} GiB"
+            )
             if isinstance(metadata, GGUFMetadata):
                 _print_row(
                     dtype.name.upper() + " " * (max_length - len(dtype.name)),
                     gib_text,
                     data_col_width,
                 )
-            else:                
+            else:
                 _print_row(
                     dtype.upper() + " " * (max_length - len(dtype)),
                     gib_text,
@@ -289,8 +290,10 @@ def print_report_for_gguf(
     ]
     first_cache = list(gguf_files.values())[0].kv_cache_info
     if first_cache is not None:
-        centered_rows.append(f"w/ max-model-len={first_cache.max_model_len}, batch-size={first_cache.batch_size}")
-    
+        centered_rows.append(
+            f"w/ max-model-len={first_cache.max_model_len}, batch-size={first_cache.batch_size}"
+        )
+
     for filename, gguf_metadata in gguf_files.items():
         centered_rows.append(filename)
 
@@ -318,9 +321,9 @@ def print_report_for_gguf(
             gib_text = f"{cache_size:.2f} / {total_gibs:.2f} GiB"
             kv_extra_info = f"(w/ max-model-len={max_model_len}, batch-size={batch_size})"
             centered_rows.append(name_text + gib_text + kv_extra_info)
-            
+
     max_centered_len = max(len(r) for r in centered_rows)
-    
+
     if max_centered_len > MAX_DATA_LEN and ignore_table_width is False:
         warnings.warn(
             f"Given that the provided `--model-id {model_id}` (with `--revision {revision}`) is longer than {MAX_DATA_LEN} characters, the table width will be expanded to fit the provided values within their row, but it might lead to unexpected table views. If you'd like to ignore the limit, then provide the `--ignore-table-width` flag to ignore the {MAX_DATA_LEN} width limit, to simply accommodate to whatever the longest text length is."
@@ -336,15 +339,7 @@ def print_report_for_gguf(
             f"w/ max-model-len={first_cache.max_model_len}, batch-size={first_cache.batch_size}",
             current_len,
         )
-    max_name_length = min(
-        max(
-            [
-                len(filename)
-                for filename in gguf_files.keys()
-            ]
-        ),
-        MAX_DATA_LEN
-    )
+    max_name_length = min(max([len(filename) for filename in gguf_files.keys()]), MAX_DATA_LEN)
     data_col_width = current_len + 2 * BORDERS_AND_PADDING - max_name_length - 5
     _print_divider(data_col_width + 1, "top", name_len=max_name_length)
 

--- a/src/hf_mem/print.py
+++ b/src/hf_mem/print.py
@@ -1,3 +1,4 @@
+from functools import cache
 import warnings
 from typing import Any, Dict, Literal, Optional
 

--- a/src/hf_mem/print.py
+++ b/src/hf_mem/print.py
@@ -342,7 +342,8 @@ def print_report_for_gguf(
     max_name_length = min(max([len(filename) for filename in gguf_files.keys()]), MAX_DATA_LEN)
     data_col_width = current_len + 2 * BORDERS_AND_PADDING - max_name_length - 5
     _print_divider(data_col_width + 1, "top", name_len=max_name_length)
-
+    _print_row("VERSION", f"hf-mem {__version__}", data_col_width, name_len=max_name_length)
+    _print_divider(data_col_width + 1, name_len=max_name_length)
     for i, (filename, gguf_metadata) in enumerate(gguf_files.items()):
         transformer = gguf_metadata.components.get("Transformer")
         if transformer and transformer.dtypes:

--- a/src/hf_mem/print.py
+++ b/src/hf_mem/print.py
@@ -30,8 +30,8 @@ def _print_with_color(content: str) -> None:
     print(f"\x1b[38;2;244;183;63m{content}\x1b[0m")
 
 
-def _print_header(current_len: int) -> None:
-    length = current_len + 2 * BORDERS_AND_PADDING + 2
+def _print_header(current_len: int, name_len: int = MAX_NAME_LEN) -> None:
+    length = current_len + name_len + BORDERS_AND_PADDING
     top = BOX["tl"] + (BOX["tsep"] * (length - 2)) + BOX["tr"]
     _print_with_color(top)
 
@@ -39,8 +39,9 @@ def _print_header(current_len: int) -> None:
     _print_with_color(bottom)
 
 
-def _print_centered(text: str, current_len: int) -> None:
-    total_width = current_len + 2 * BORDERS_AND_PADDING
+def _print_centered(text: str, current_len: int, name_len: int = MAX_NAME_LEN) -> None:
+    max_len = current_len + name_len - BORDERS_AND_PADDING
+    total_width = max_len + 12
     text_len = len(text)
     pad_left = (total_width - text_len) // 2
     pad_right = total_width - text_len - pad_left
@@ -75,12 +76,12 @@ def _print_divider(
     _print_with_color(line)
 
 
-def _format_name(name: str, max_len: int = MAX_NAME_LEN) -> str:
+def _format_name(name: str, name_len: int = MAX_NAME_LEN) -> str:
     if len(name) < MIN_NAME_LEN:
         return f"{name:<{MIN_NAME_LEN}}"
-    if len(name) > max_len:
-        return name[: max_len - 3] + "..."
-    return f"{name:<{max_len}}"
+    if len(name) > name_len:
+        return name[: name_len - 3] + "..."
+    return f"{name:<{name_len}}"
 
 
 def _print_row(name: str, text: str, current_len: int, name_len: int = MAX_NAME_LEN) -> None:
@@ -269,66 +270,17 @@ def print_report(
     _print_divider(current_len + 1, "bottom")
 
 
-def _print_header_gguf(current_len: int, name_len: int) -> None:
-    length = current_len + name_len + BORDERS_AND_PADDING
-    top = BOX["tl"] + (BOX["tsep"] * (length - 2)) + BOX["tr"]
-    _print_with_color(top)
-
-    bottom = BOX["lm"] + (BOX["bsep"] * (length - 2)) + BOX["rm"]
-    _print_with_color(bottom)
-
-
-def _print_centered_gguf(text: str, current_len: int, name_len: int) -> None:
-    max_len = current_len + name_len - BORDERS_AND_PADDING
-    total_width = max_len + 12
-    text_len = len(text)
-    pad_left = (total_width - text_len) // 2
-    pad_right = total_width - text_len - pad_left
-    _print_with_color(f"{BOX['vt']}{' ' * pad_left}{text}{' ' * pad_right}{BOX['vt']}")
-
-
-def _print_divider_gguf(
-    current_len: int,
-    name_len: int,
-    side: Optional[Literal["top", "top-continue", "bottom", "bottom-continue"]] = None,
-) -> None:
-    match side:
-        case "top":
-            left, mid, right = BOX["lm"], BOX["tsep"], BOX["rm"]
-        case "top-continue":
-            left, mid, right = BOX["lm"], BOX["bsep"], BOX["rm"]
-        case "bottom":
-            left, mid, right = BOX["bl"], BOX["bsep"], BOX["br"]
-        case "bottom-continue":
-            left, mid, right = BOX["lm"], BOX["bsep"], BOX["rm"]
-        case _:
-            left, mid, right = BOX["lm"], BOX["mm"], BOX["rm"]
-
-    name_col_inner = name_len + 2
-    data_col_inner = current_len + 1
-
-    line = left
-    line += BOX["ht"] * name_col_inner
-    line += mid
-    line += BOX["ht"] * data_col_inner
-    line += right
-    _print_with_color(line)
-
-
-def _print_row_gguf(name: str, text: str, current_len: int, name_len: int) -> None:
-    name_fmt = f"{name:<{name_len}}"
-    data_fmt = f"{str(text):<{current_len}}"
-    _print_with_color(f"{BOX['vt']} {name_fmt} {BOX['vt']} {data_fmt} {BOX['vt']}")
-
-
 def _group_gguf_files(gguf_files: Dict[str, int]) -> Dict[str, int]:
     """Group sharded GGUF files by model variant and sum their sizes.
 
     Files like 'BF16/model-00001-of-00010.gguf' are grouped together.
+    For example, 'BF16/model-00001-of-00010.gguf' and 'BF16/model-00002-of-00010.gguf'
+    are grouped under 'BF16/model.gguf'.
     Single files like 'model-Q4_K_M.gguf' remain as-is.
+    Supports various shard formats: -1-of-2.gguf, -001-of-002.gguf, -00001-of-00010.gguf, etc.
     """
     grouped: Dict[str, int] = {}
-    shard_pattern = re.compile(r"-\d{5}-of-\d{5}\.gguf$")
+    shard_pattern = re.compile(r"-\d+-of-\d+\.gguf$")
 
     for path, size in gguf_files.items():
         if shard_pattern.search(path):
@@ -374,16 +326,16 @@ def print_report_for_gguf(
 
     current_len = min(max_len, MAX_DATA_LEN) if ignore_table_width is False else max_len
 
-    _print_header_gguf(current_len, max_name_len)
-    _print_centered_gguf("INFERENCE MEMORY ESTIMATE FOR", current_len, max_name_len)
-    _print_centered_gguf(f"https://hf.co/{model_id} @ {revision}", current_len, max_name_len)
-    _print_divider_gguf(current_len + 1, max_name_len, "top")
+    _print_header(current_len, max_name_len)
+    _print_centered("INFERENCE MEMORY ESTIMATE FOR", current_len, max_name_len)
+    _print_centered(f"https://hf.co/{model_id} @ {revision}", current_len, max_name_len)
+    _print_divider(current_len + 1, "top", max_name_len)
 
     for i, (filename, size_bytes) in enumerate(grouped_files.items()):
-        file_gb = _bytes_to_gib(size_bytes)
-        _print_row_gguf(filename, f"{file_gb:.2f} GB", current_len, max_name_len)
+        file_gb = _bytes_to_gb(size_bytes, use_decimal=True)
+        _print_row(filename, f"{file_gb:.2f} GB", current_len, max_name_len)
 
         if i < len(grouped_files) - 1:
-            _print_divider_gguf(current_len + 1, max_name_len)
+            _print_divider(current_len + 1, name_len=max_name_len)
 
-    _print_divider_gguf(current_len + 1, max_name_len, "bottom")
+    _print_divider(current_len + 1, "bottom", max_name_len)

--- a/src/hf_mem/types.py
+++ b/src/hf_mem/types.py
@@ -17,6 +17,34 @@ SafetensorsDtypes = Literal[
     "U8",
 ]
 
+GGUFDtypeBitsPerWeight = {
+    # .GGUF specific dtypes
+    "Q8_K": 8.03125,
+    "Q6_K": 6.5625,
+    "Q5_K": 5.5,
+    "Q4_K": 4.5,
+    "Q3_K": 3.4375,
+    "Q2_K": 2.625,
+    "IQ4_NL": 4.5,
+    "IQ4_XS": 4.25,
+    "IQ3_S": 3.44,
+    "IQ3_XXS": 3.06,
+    "IQ2_XXS": 2.06,
+    "IQ2_S": 2.5,
+    "IQ2_XS": 2.31,
+    "IQ1_S": 1.56,
+    "IQ1_M": 1.75,
+    "TQ1_0": 1.6875,
+    "TQ2_0": 2.0625,
+    "MXFP4": 4.25,
+    # .GGUF specific dtypes (legacy type, added for exhaustivity)
+    "Q8_0": 8.5,
+    "Q8_1": 9,
+    "Q5_0": 5.5,
+    "Q5_1": 6,
+    "Q4_0": 4.5,
+    "Q4_1": 5,
+}
 
 def get_safetensors_dtype_bytes(dtype: SafetensorsDtypes | str) -> int:
     match dtype:
@@ -55,3 +83,11 @@ def torch_dtype_to_safetensors_dtype(dtype: TorchDtypes | str) -> SafetensorsDty
             return "I8"
         case _:
             return "F16"
+def get_gguf_dtype_bytes(dtype: str) -> float:
+    if dtype in SafetensorsDtypes:
+        return float(get_safetensors_dtype_bytes(dtype=dtype))
+    
+    if dtype not in GGUFDtypeBitsPerWeight.keys():
+        raise RuntimeError(f"DTYPE={dtype} NOT HANDLED")
+    
+    return GGUFDtypeBitsPerWeight[dtype] / 8.0 # bit to byte conversion

--- a/src/hf_mem/types.py
+++ b/src/hf_mem/types.py
@@ -17,34 +17,6 @@ SafetensorsDtypes = Literal[
     "U8",
 ]
 
-GGUFDtypeBitsPerWeight = {
-    # .GGUF specific dtypes
-    "Q8_K": 8.03125,
-    "Q6_K": 6.5625,
-    "Q5_K": 5.5,
-    "Q4_K": 4.5,
-    "Q3_K": 3.4375,
-    "Q2_K": 2.625,
-    "IQ4_NL": 4.5,
-    "IQ4_XS": 4.25,
-    "IQ3_S": 3.44,
-    "IQ3_XXS": 3.06,
-    "IQ2_XXS": 2.06,
-    "IQ2_S": 2.5,
-    "IQ2_XS": 2.31,
-    "IQ1_S": 1.56,
-    "IQ1_M": 1.75,
-    "TQ1_0": 1.6875,
-    "TQ2_0": 2.0625,
-    "MXFP4": 4.25,
-    # .GGUF specific dtypes (legacy type, added for exhaustivity)
-    "Q8_0": 8.5,
-    "Q8_1": 9,
-    "Q5_0": 5.5,
-    "Q5_1": 6,
-    "Q4_0": 4.5,
-    "Q4_1": 5,
-}
 
 def get_safetensors_dtype_bytes(dtype: SafetensorsDtypes | str) -> int:
     match dtype:
@@ -83,11 +55,3 @@ def torch_dtype_to_safetensors_dtype(dtype: TorchDtypes | str) -> SafetensorsDty
             return "I8"
         case _:
             return "F16"
-def get_gguf_dtype_bytes(dtype: str) -> float:
-    if dtype in SafetensorsDtypes:
-        return float(get_safetensors_dtype_bytes(dtype=dtype))
-    
-    if dtype not in GGUFDtypeBitsPerWeight.keys():
-        raise RuntimeError(f"DTYPE={dtype} NOT HANDLED")
-    
-    return GGUFDtypeBitsPerWeight[dtype] / 8.0 # bit to byte conversion


### PR DESCRIPTION
## Description

<!-- What does this PR change, and why? Include any relevant context or links. -->

This PR continues on top of the work of @vm7608 in #8. It aims to add support for GGUF files by:
- Adding `--gguf` flag to separate .safetensors from .gguf estimations.
- Adding support for new .gguf dtypes.
- Parsing .gguf metadata to estimate both model and kv cache sizes.

(I'm starting it as a draft pull request to show the progress and explain decisions along)

---

- [x] I have read and followed the guidelines in [`CONTRIBUTING.md`](/CONTRIBUTING.md).
- [x] This has been discussed over an issue or discussion.
