### PR TITLE
feat: support for nested text_config in config.json (Kimi K2.5)

### DIFF
--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -328,8 +328,13 @@ async def run(
                     2
                     * _get_config_value(config, "num_hidden_layers")
                     # NOTE: `num_key_value_heads` defaults to `num_attention_heads` in MHA
-                    * _get_config_value(config, "num_key_value_heads", _get_config_value(config, "num_attention_heads"))
-                    * (_get_config_value(config, "hidden_size") // _get_config_value(config, "num_attention_heads"))
+                    * _get_config_value(
+                        config, "num_key_value_heads", _get_config_value(config, "num_attention_heads")
+                    )
+                    * (
+                        _get_config_value(config, "hidden_size")
+                        // _get_config_value(config, "num_attention_heads")
+                    )
                     * max_model_len
                     * get_safetensors_dtype_bytes(cache_dtype)
                 )

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -79,6 +79,20 @@ async def fetch_modules_and_dense_metadata(
     return dense_metadata
 
 
+def _get_config_value(config: Dict[str, Any], key: str, default: Any = None) -> Any:
+    """Get value from config, falling back to text_config if present.
+
+    Some multimodal models (e.g., Kimi-K2.5, LLaVA) store their transformer
+    configuration in a nested `text_config` dictionary. This helper handles
+    both top-level and nested configurations.
+    """
+    if key in config:
+        return config[key]
+    if "text_config" in config and isinstance(config["text_config"], dict) and key in config["text_config"]:
+        return config["text_config"][key]
+    return default
+
+
 async def run(
     model_id: str,
     revision: str,
@@ -258,19 +272,22 @@ async def run(
                 )
             else:
                 if max_model_len is None:
-                    max_model_len = config.get(
-                        "max_position_embeddings",
-                        config.get("n_positions", config.get("max_seq_len", max_model_len)),
-                    )
+                    max_model_len = _get_config_value(config, "max_position_embeddings")
+                if max_model_len is None:
+                    max_model_len = _get_config_value(config, "n_positions")
+                if max_model_len is None:
+                    max_model_len = _get_config_value(config, "max_seq_len")
 
                 if max_model_len is None:
                     warnings.warn(
-                        f"Either the `--max-model-len` was not set, not available in `config.json` with the any of the keys: `max_position_embeddings`, `n_positions`, or `max_seq_len` (in that order of priority), or both; so the memory required to fit the context length cannot be estimated."
+                        f"Either the `--max-model-len` was not set, not available in `config.json` (including `text_config` if present) with the any of the keys: `max_position_embeddings`, `n_positions`, or `max_seq_len` (in that order of priority), or both; so the memory required to fit the context length cannot be estimated."
                     )
 
-                if not all(k in config for k in {"hidden_size", "num_hidden_layers", "num_attention_heads"}):  # type: ignore
+                required_keys = {"hidden_size", "num_hidden_layers", "num_attention_heads"}
+                missing_keys = [k for k in required_keys if _get_config_value(config, k) is None]
+                if missing_keys:
                     warnings.warn(
-                        f"`config.json` doesn't contain all the keys `hidden_size`, `num_hidden_layers`, and `num_attention_heads`, but only {config.keys()}."  # type: ignore
+                        f"`config.json` doesn't contain all the required keys {missing_keys} (checked both top-level and text_config if present)."
                     )
 
                 if kv_cache_dtype in {"fp8_e5m2", "fp8_e4m3"}:
@@ -309,10 +326,10 @@ async def run(
                 cache_size = (
                     # NOTE: 2 because it applies to both key and value projections
                     2
-                    * config.get("num_hidden_layers")  # type: ignore
+                    * _get_config_value(config, "num_hidden_layers")
                     # NOTE: `num_key_value_heads` defaults to `num_attention_heads` in MHA
-                    * config.get("num_key_value_heads", config.get("num_attention_heads"))  # type: ignore
-                    * (config.get("hidden_size") // config.get("num_attention_heads"))  # type: ignore
+                    * _get_config_value(config, "num_key_value_heads", _get_config_value(config, "num_attention_heads"))
+                    * (_get_config_value(config, "hidden_size") // _get_config_value(config, "num_attention_heads"))
                     * max_model_len
                     * get_safetensors_dtype_bytes(cache_dtype)
                 )


### PR DESCRIPTION
## Description

This PR adds support for reading model config from the "text_config" nested field in `config.json`

Some models, like Kimi K2.5 and LLaVa have their transformers config in a nested `text_config` field that is nested. 
Before this PR, if you run `hf-mem --model-id moonshotai/Kimi-K2.5 --experimental` or `llava-hf/llava-1.5-13b-hf`, an error is thrown:

```
Traceback (most recent call last):
  File "/Users/napuh/CODE/hf_mem_website/.venv/bin/hf-mem", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/napuh/CODE/hf_mem_website/.venv/lib/python3.12/site-packages/hf_mem/cli.py", line 410, in main
    asyncio.run(
  File "/Users/napuh/.local/share/uv/python/cpython-3.12.11-macos-aarch64-none/lib/python3.12/asyncio/runners.py", line 195, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/Users/napuh/.local/share/uv/python/cpython-3.12.11-macos-aarch64-none/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/napuh/.local/share/uv/python/cpython-3.12.11-macos-aarch64-none/lib/python3.12/asyncio/base_events.py", line 691, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/napuh/CODE/hf_mem_website/.venv/lib/python3.12/site-packages/hf_mem/cli.py", line 311, in run
    2
TypeError: unsupported operand type(s) for *: 'int' and 'NoneType'
```

And now, `hf-mem` can read the config correctly.

You can test this via:

- `hf-mem --model-id llava-hf/llava-1.5-13b-hf --experimental`
- `hf-mem --model-id moonshotai/Kimi-K2.5 --experimental`
---

- [x] I have read and followed the guidelines in [`CONTRIBUTING.md`](/CONTRIBUTING.md).
- [ ] This has been discussed over an issue or discussion.
