### PR TITLE
Add `[project.urls]` to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,11 @@ dependencies = [
     "httpx[http2]>=0.28.1",
 ]
 
+[project.urls]
+Homepage = "https://github.com/alvarobartt/hf-mem"
+Repository = "https://github.com/alvarobartt/hf-mem"
+Issues = "https://github.com/alvarobartt/hf-mem/issues"
+
 [build-system]
 requires = ["uv_build>=0.9.5,<0.10.0"]
 build-backend = "uv_build"


### PR DESCRIPTION
## Description

This PR adds some metadata to `pyproject.toml` as per https://packaging.python.org/en/latest/guides/writing-pyproject-toml/, so as to enhance the https://pypi.org/project/hf-mem page with some useful links.

---

- [x] I have read and followed the guidelines in [`CONTRIBUTING.md`](/CONTRIBUTING.md).
- [ ] This has been discussed over an issue or discussion.