### PR TITLE
Fix `quantization_config` parsing for `--kv-cache-dtype=auto`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hf-mem"
-version = "0.4.3"
+version = "0.4.4"
 description = "A CLI to estimate inference memory requirements for Hugging Face models, written in Python."
 readme = "README.md"
 authors = [

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -290,10 +290,6 @@ async def run(
                     cache_dtype = "FP8"
                 elif kv_cache_dtype == "bfloat16":
                     cache_dtype = "BF16"
-                elif _cache_dtype := config.get("torch_dtype", None):
-                    cache_dtype = torch_dtype_to_safetensors_dtype(_cache_dtype)
-                elif _cache_dtype := config.get("dtype", None):
-                    cache_dtype = torch_dtype_to_safetensors_dtype(_cache_dtype)
                 elif "quantization_config" in config and "quant_method" in config["quantization_config"]:
                     _quantization_config = config["quantization_config"]
                     _quant_method = _quantization_config["quant_method"]
@@ -313,6 +309,10 @@ async def run(
                         cache_dtype = torch_dtype_to_safetensors_dtype(_fmt)
                     else:
                         cache_dtype = _quant_method.upper()
+                elif _cache_dtype := config.get("torch_dtype", None):
+                    cache_dtype = torch_dtype_to_safetensors_dtype(_cache_dtype)
+                elif _cache_dtype := config.get("dtype", None):
+                    cache_dtype = torch_dtype_to_safetensors_dtype(_cache_dtype)
                 else:
                     raise RuntimeError(
                         f"Provided `--kv-cache-dtype={kv_cache_dtype}` but it needs to be any of `auto`, `bfloat16`, `fp8`, `fp8_ds_mla`, `fp8_e4m3`, `fp8_e5m2` or `fp8_inc`. If `auto` is set, then the `config.json` should either contain the `torch_dtype` or `dtype` fields set, or if quantized then `quantization_config` needs to be set and contain the key `quant_method` with value `fp8` (as any of `fp32`, `fp16` or `bf16` is considered within the `quantization_config`), and optionally also contain `fmt` set to any valid format as `float8`, `float8_e4m3` or `float8_e4m3fn`."

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -285,9 +285,13 @@ async def run(
                 if kv_cache_dtype in {"fp8_e5m2", "fp8_e4m3"}:
                     cache_dtype = kv_cache_dtype.upper().replace("FP8", "F8")
                 elif kv_cache_dtype in {"fp8", "fp8_ds_mla", "fp8_inc"}:
-                    # NOTE: Default to `FP8` for the calculations, given that all those take 1 byte, but only FP8
-                    # is supported in Safetensors, whilst FP8_DS_MLA (DeepSeek MLA) and FP8_INC (Intel HPUs) are not
-                    cache_dtype = "FP8"
+                    # NOTE: Default to `F8_E4M3` for the calculations, given that all those take 1 byte, but only F8_E5M2
+                    # or `F8_E4M3` are supported in Safetensors, whilst `FP8_DS_MLA` (DeepSeek MLA) and `FP8_INC` (Intel HPUs)
+                    # are not; and `F8_E4M3` is supported on both CUDA and AMD, hence seems a reasonable default
+                    warnings.warn(
+                        f"--kv-cache-dtype={kv_cache_dtype}` has been provided, but given that none of those matches an actual Safetensors dtype since it should be any of `F8_E5M2` or `F8_E4M3`, the `--kv-cache-dtype` will default to `F8_E4M3` instead, which implies that the calculations are the same given that both dtypes take 1 byte despite the quantization scheme of it, or the hardware compatibility; so the estimations should be accurate enough."
+                    )
+                    cache_dtype = "F8_E4M3"
                 elif kv_cache_dtype == "bfloat16":
                     cache_dtype = "BF16"
                 elif "quantization_config" in config and "quant_method" in config["quantization_config"]:

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -315,7 +315,30 @@ async def run(
 
                         cache_dtype = torch_dtype_to_safetensors_dtype(_fmt)
                     else:
-                        cache_dtype = _quant_method.upper()
+                        # NOTE: If `quant_method` in `quantization_config` is set to `fp8` and `fmt` is not set, then
+                        # we get the most used `F8_*` Safetensors dtype to map the `quant_method=fp8` to an actual Safetensors
+                        # dtype, as `F8` is not a valid dtype neither on PyTorch nor on Safetensors, as we need to append
+                        # the scheme / format.
+                        # SAFETY: As per the snippets above, if `_fmt` is None we assume that `_quant_method=fp8`
+                        cache_dtype = max(
+                            (
+                                l := [
+                                    d
+                                    for c in metadata.components.values()
+                                    for d in c.dtypes.keys()
+                                    if d in {"F8_E5M2", "F8_E4M3"}
+                                ]
+                            ),
+                            key=l.count,
+                            default=None,
+                        )
+
+                        # TODO: Not sure if we should default to `F8_E4M3` as a reasonable default as when `FP8`,
+                        # `FP8_DS_MLA` or `FP8_INC` are provided... to prevent raising an exception
+                        if not cache_dtype:
+                            raise RuntimeError(
+                                f"The `config.json` file for `--model-id={model_id}` contains `quantization_config={_quantization_config}` but the `quant_method=fp8` whereas any tensor in the model weights is set to any of `F8_E4M3` nor `F8_E5M2`, which means that the `F8_` format for the Safetensors dtype cannot be inferred; so you might need to set `--kv-cache-dtype=fp8` to enforce the dtype instead of pulling it from the `config.json`.\nAs KV cache estimation is still experimental, as that might not be the case for your model, then feel free to open an issue at https://github.com/alvarobartt/hf-mem with a report and eventually what solution you would like to see implemented."
+                            )
                 elif _cache_dtype := config.get("torch_dtype", None):
                     cache_dtype = torch_dtype_to_safetensors_dtype(_cache_dtype)
                 elif _cache_dtype := config.get("dtype", None):

--- a/src/hf_mem/types.py
+++ b/src/hf_mem/types.py
@@ -45,7 +45,7 @@ def torch_dtype_to_safetensors_dtype(dtype: TorchDtypes | str) -> SafetensorsDty
             return "F16"
         case "bfloat16":
             return "BF16"
-        case "float8_e4m3fn" | "float8_e4m3fn":
+        case "float8_e4m3" | "float8_e4m3fn":
             return "F8_E4M3"
         case "float8_e5m2":
             return "F8_E5M2"

--- a/src/hf_mem/types.py
+++ b/src/hf_mem/types.py
@@ -49,5 +49,7 @@ def torch_dtype_to_safetensors_dtype(dtype: TorchDtypes | str) -> SafetensorsDty
             return "F8_E4M3"
         case "float8_e5m2":
             return "F8_E5M2"
+        case "int8":
+            return "I8"
         case _:
             return "F16"

--- a/src/hf_mem/types.py
+++ b/src/hf_mem/types.py
@@ -49,6 +49,8 @@ def torch_dtype_to_safetensors_dtype(dtype: TorchDtypes | str) -> SafetensorsDty
             return "F8_E4M3"
         case "float8_e5m2":
             return "F8_E5M2"
+        # NOTE: `I8` is usally not used for quantizing i.e., the KV cache will never be of type `I8`, hence this
+        # case might never be hit
         case "int8":
             return "I8"
         case _:

--- a/uv.lock
+++ b/uv.lock
@@ -88,7 +88,7 @@ wheels = [
 
 [[package]]
 name = "hf-mem"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", extra = ["http2"] },


### PR DESCRIPTION
## Description

> [!WARNING]
> This PR constitutes a breaking change given that as there was a bug before with the parsing order where `dtype` (and `torch_dtype`) where being parsed as the default `--kv-cache-dtype` when `--kv-cache-dtype=auto` (or simply not set); the actual dtype from the `quantization_config` was not being used as the default option, meaning that now models with a `dtype` or `torch_dtype` set with an invalid `quantization_config` will raise a `RuntimeError` whereas before those where working "fine", just estimating the KV cache requirements with a "wrong" dtype.

This PR fixes the placement of the `quantization_config` to have more priority if there than `dtype` or `torch_dtype`, as well as bumping the version to 0.4.4 with `uv version 0.4.4`.

---

- [x] I have read and followed the guidelines in [`CONTRIBUTING.md`](/CONTRIBUTING.md).
- [ ] This has been discussed over an issue or discussion.