### PR TITLE
(fix) Fetch referenced config on models that require it

### DIFF
--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -276,7 +276,9 @@ async def run(
                             warnings.warn(
                                 f"The `text_config` contains `_name_or_path={referenced_model}`, so fetching the config from `{referenced_model}` to retrieve the required fields for KV cache estimation."
                             )
-                            text_config = await get_json_file(client, referenced_url, headers)
+                            referenced_config = await get_json_file(client, referenced_url, headers)
+                            referenced_config.update(text_config)
+                            text_config = referenced_config
 
                     config = text_config
 

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -265,7 +265,20 @@ async def run(
                     warnings.warn(
                         f"Given that `--model-id={model_id}` is a `...ForConditionalGeneration` model, then the configuration from `config.json` will be retrieved from the key `text_config` instead."
                     )
-                    config = config["text_config"]
+                    text_config = config["text_config"]
+
+                    if "_name_or_path" in text_config:
+                        referenced_model = text_config["_name_or_path"]
+                        if referenced_model:
+                            referenced_url = (
+                                f"https://huggingface.co/{referenced_model}/resolve/{revision}/config.json"
+                            )
+                            warnings.warn(
+                                f"The `text_config` contains `_name_or_path={referenced_model}`, so fetching the config from `{referenced_model}` to retrieve the required fields for KV cache estimation."
+                            )
+                            text_config = await get_json_file(client, referenced_url, headers)
+
+                    config = text_config
 
                 if max_model_len is None:
                     max_model_len = config.get(

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -267,18 +267,16 @@ async def run(
                     )
                     text_config = config["text_config"]
 
-                    if "_name_or_path" in text_config:
-                        referenced_model = text_config["_name_or_path"]
-                        if referenced_model:
-                            referenced_url = (
-                                f"https://huggingface.co/{referenced_model}/resolve/{revision}/config.json"
-                            )
-                            warnings.warn(
-                                f"The `text_config` contains `_name_or_path={referenced_model}`, so fetching the config from `{referenced_model}` to retrieve the required fields for KV cache estimation."
-                            )
-                            referenced_config = await get_json_file(client, referenced_url, headers)
-                            referenced_config.update(text_config)
-                            text_config = referenced_config
+                    if referenced_model := text_config.get("_name_or_path"):
+                        referenced_url = (
+                            f"https://huggingface.co/{referenced_model}/resolve/{revision}/config.json"
+                        )
+                        warnings.warn(
+                            f"The `text_config` contains `_name_or_path={referenced_model}`, so fetching the config from `{referenced_model}` to retrieve the required fields for KV cache estimation."
+                        )
+                        referenced_config = await get_json_file(client, referenced_url, headers)
+                        referenced_config.update(text_config)
+                        text_config = referenced_config
 
                     config = text_config
 


### PR DESCRIPTION
## Description

Some models, like llava-hf/llava-1.5-7b-hf have the necessary config to calculate the KV cache size referenced to other models. For example:

```json

"text_config": {
  "_name_or_path": "lmsys/vicuna-7b-v1.5",
  "architectures": [
  "LlamaForCausalLM"
  ],
  "max_position_embeddings": 4096,
  "model_type": "llama",
  "rms_norm_eps": 1e-05,
  "torch_dtype": "float16",
  "vocab_size": 32064
}
```

Estimating the memory requirements for this model with the `--experimental` flag for KV-cache size estimation, throws and error:

`TypeError: unsupported operand type(s) for *: 'int' and 'NoneType'`

This PR allows to fetch the referenced config, and use those values to estimate the KV-cache size. If the `_name_or_path` key is present in `text_config`, it uses those values as a base for LLM parameters (num_hidden_layers, hidden_size, etc.), and then overwrites with values from the original text_config (like max_position_embeddings, which may have been modified)

Before this PR, `...ForConditionalGeneration`models with referenced configs failed to calculate the KV-cache size:

```
hf-mem --model-id llava-hf/llava-1.5-7b-hf --experimental

Traceback (most recent call last):
  File "/Users/napuh/CODE/hf-mem/.venv/bin/hf-mem", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/napuh/CODE/hf-mem/src/hf_mem/cli.py", line 457, in main
    asyncio.run(
  File "/Users/napuh/.local/share/uv/python/cpython-3.12.11-macos-aarch64-none/lib/python3.12/asyncio/runners.py", line 195, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/Users/napuh/.local/share/uv/python/cpython-3.12.11-macos-aarch64-none/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/napuh/.local/share/uv/python/cpython-3.12.11-macos-aarch64-none/lib/python3.12/asyncio/base_events.py", line 691, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/napuh/CODE/hf-mem/src/hf_mem/cli.py", line 355, in run
    2
TypeError: unsupported operand type(s) for *: 'int' and 'NoneType'
```

After this PR, the command executes succesfully.


---

- [x] I have read and followed the guidelines in [`CONTRIBUTING.md`](/CONTRIBUTING.md).
- [ ] This has been discussed over an issue or discussion.
