### PR TITLE
feat: add local file and directory support for safetensors and GGUF

### DIFF
--- a/src/hf_mem/_local.py
+++ b/src/hf_mem/_local.py
@@ -1,0 +1,57 @@
+import json
+import os
+import struct
+from typing import Any, Dict, List
+
+# Cap for GGUF header reads — metadata sections rarely exceed this
+_MAX_GGUF_READ_SIZE = 100_000_000  # 100 MB
+
+
+def list_local_files(directory: str) -> List[str]:
+    """Walk directory and return relative file paths, following symlinks."""
+    file_paths = []
+    for root, _dirs, files in os.walk(directory, followlinks=True):
+        for f in files:
+            full_path = os.path.join(root, f)
+            # Skip broken symlinks
+            if not os.path.exists(full_path):
+                continue
+            rel_path = os.path.relpath(full_path, directory)
+            file_paths.append(rel_path)
+    return file_paths
+
+
+def read_safetensors_header(filepath: str) -> Dict[str, Any]:
+    """Read safetensors metadata header from a local file.
+
+    Returns the same dict shape as fetch_safetensors_metadata() returns from HTTP.
+    """
+    with open(filepath, "rb") as f:
+        size_bytes = f.read(8)
+        if len(size_bytes) < 8:
+            raise RuntimeError(f"File too small to be a valid safetensors file: {filepath}")
+        metadata_size = struct.unpack("<Q", size_bytes)[0]
+        metadata_bytes = f.read(metadata_size)
+        if len(metadata_bytes) < metadata_size:
+            raise RuntimeError(
+                f"Safetensors header truncated in {filepath}: expected {metadata_size} bytes, got {len(metadata_bytes)}"
+            )
+    raw = json.loads(metadata_bytes)
+    # Remove __metadata__ key to match the shape returned by HTTP fetch
+    # (the HTTP path returns the full dict including __metadata__, and
+    # parse_safetensors_metadata skips it via the `if key in {"__metadata__"}` check)
+    return raw
+
+
+def read_local_json(filepath: str) -> Any:
+    """Read and parse a local JSON file."""
+    with open(filepath, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def read_gguf_bytes(filepath: str) -> bytes:
+    """Read GGUF file header bytes (up to 100MB) for metadata parsing."""
+    file_size = os.path.getsize(filepath)
+    read_size = min(file_size, _MAX_GGUF_READ_SIZE)
+    with open(filepath, "rb") as f:
+        return f.read(read_size)

--- a/src/hf_mem/_local.py
+++ b/src/hf_mem/_local.py
@@ -3,6 +3,7 @@ import os
 import struct
 from typing import Any, Dict, List
 
+_MAX_HEADER_SIZE = 100_000_000
 _MAX_GGUF_READ_SIZE = 100_000_000
 
 
@@ -14,7 +15,7 @@ def list_local_files(directory: str) -> List[str]:
             full_path = os.path.join(root, f)
             if not os.path.exists(full_path):
                 continue
-            rel_path = os.path.relpath(full_path, directory)
+            rel_path = os.path.relpath(full_path, directory).replace(os.sep, "/")
             file_paths.append(rel_path)
     return file_paths
 
@@ -25,6 +26,8 @@ def read_safetensors_header(filepath: str) -> Dict[str, Any]:
         if len(size_bytes) < 8:
             raise RuntimeError(f"File too small to be a valid safetensors file: {filepath}")
         metadata_size = struct.unpack("<Q", size_bytes)[0]
+        if metadata_size > _MAX_HEADER_SIZE:
+            raise RuntimeError(f"Safetensors header size ({metadata_size} bytes) exceeds limit in {filepath}")
         metadata_bytes = f.read(metadata_size)
         if len(metadata_bytes) < metadata_size:
             raise RuntimeError(

--- a/src/hf_mem/_local.py
+++ b/src/hf_mem/_local.py
@@ -3,17 +3,15 @@ import os
 import struct
 from typing import Any, Dict, List
 
-# Cap for GGUF header reads — metadata sections rarely exceed this
-_MAX_GGUF_READ_SIZE = 100_000_000  # 100 MB
+_MAX_GGUF_READ_SIZE = 100_000_000
 
 
 def list_local_files(directory: str) -> List[str]:
-    """Walk directory and return relative file paths, following symlinks."""
     file_paths = []
     for root, _dirs, files in os.walk(directory, followlinks=True):
+        _dirs[:] = [d for d in _dirs if not d.startswith(".")]
         for f in files:
             full_path = os.path.join(root, f)
-            # Skip broken symlinks
             if not os.path.exists(full_path):
                 continue
             rel_path = os.path.relpath(full_path, directory)
@@ -22,10 +20,6 @@ def list_local_files(directory: str) -> List[str]:
 
 
 def read_safetensors_header(filepath: str) -> Dict[str, Any]:
-    """Read safetensors metadata header from a local file.
-
-    Returns the same dict shape as fetch_safetensors_metadata() returns from HTTP.
-    """
     with open(filepath, "rb") as f:
         size_bytes = f.read(8)
         if len(size_bytes) < 8:
@@ -36,21 +30,15 @@ def read_safetensors_header(filepath: str) -> Dict[str, Any]:
             raise RuntimeError(
                 f"Safetensors header truncated in {filepath}: expected {metadata_size} bytes, got {len(metadata_bytes)}"
             )
-    raw = json.loads(metadata_bytes)
-    # Remove __metadata__ key to match the shape returned by HTTP fetch
-    # (the HTTP path returns the full dict including __metadata__, and
-    # parse_safetensors_metadata skips it via the `if key in {"__metadata__"}` check)
-    return raw
+    return json.loads(metadata_bytes)
 
 
 def read_local_json(filepath: str) -> Any:
-    """Read and parse a local JSON file."""
     with open(filepath, "r", encoding="utf-8") as f:
         return json.load(f)
 
 
 def read_gguf_bytes(filepath: str) -> bytes:
-    """Read GGUF file header bytes (up to 100MB) for metadata parsing."""
     file_size = os.path.getsize(filepath)
     read_size = min(file_size, _MAX_GGUF_READ_SIZE)
     with open(filepath, "rb") as f:

--- a/src/hf_mem/_print.py
+++ b/src/hf_mem/_print.py
@@ -129,5 +129,11 @@ def _format_short_number(n: float) -> str:
     return f"{n:.2f}P"
 
 
+def _format_model_label(model_id: str, revision: str) -> str:
+    if revision == "local":
+        return model_id
+    return f"https://hf.co/{model_id} @ {revision}"
+
+
 def _bytes_to_gib(nbytes: int) -> float:
     return nbytes / (1024**3)

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -43,7 +43,11 @@ def _print_result(result: Result) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser()
 
-    parser.add_argument("--model-id", required=True, help="Model ID on the Hugging Face Hub")
+    parser.add_argument(
+        "--model-id",
+        required=True,
+        help="Model ID on the Hugging Face Hub (e.g. meta-llama/Llama-3) or a local path to a .safetensors/.gguf file or a model directory (e.g. ./my-model/). Local paths must contain a path separator (use ./ prefix for relative paths).",
+    )
     parser.add_argument(
         "--revision",
         default="main",

--- a/src/hf_mem/gguf/print.py
+++ b/src/hf_mem/gguf/print.py
@@ -6,6 +6,7 @@ from hf_mem._print import (
     MAX_DATA_LEN,
     MAX_NAME_LEN,
     _bytes_to_gib,
+    _format_model_label,
     _format_short_number,
     _make_bar,
     _print_centered,
@@ -30,7 +31,7 @@ def print_gguf_report(
 
     centered_rows = [
         "INFERENCE MEMORY ESTIMATE FOR",
-        f"https://hf.co/{model_id} @ {revision}",
+        _format_model_label(model_id, revision),
         f"FOR `{filename}`",
     ]
     if kv_cache:
@@ -82,7 +83,7 @@ def print_gguf_report(
 
     _print_header(current_len, badge=f"hf-mem v{__version__}")
     _print_centered("INFERENCE MEMORY ESTIMATE FOR", current_len)
-    _print_centered(f"https://hf.co/{model_id} @ {revision}", current_len)
+    _print_centered(_format_model_label(model_id, revision), current_len)
     _print_centered(f"FOR `{filename}`", current_len)
     if kv_cache:
         _print_centered(
@@ -182,7 +183,7 @@ def print_gguf_files_report(
 
     centered_rows = [
         "INFERENCE MEMORY ESTIMATE FOR",
-        f"https://hf.co/{model_id} @ {revision}",
+        _format_model_label(model_id, revision),
     ]
     if kv_cache_config is not None:
         centered_rows.append(
@@ -227,7 +228,7 @@ def print_gguf_files_report(
 
     _print_header(current_len, badge=f"hf-mem v{__version__}")
     _print_centered("INFERENCE MEMORY ESTIMATE FOR", current_len)
-    _print_centered(f"https://hf.co/{model_id} @ {revision}", current_len)
+    _print_centered(_format_model_label(model_id, revision), current_len)
     if kv_cache_config is not None:
         _print_centered(
             f"w/ max-model-len={kv_cache_config.max_model_len}, batch-size={kv_cache_config.batch_size}",

--- a/src/hf_mem/run.py
+++ b/src/hf_mem/run.py
@@ -10,10 +10,11 @@ from uuid import uuid4
 import httpx
 
 from hf_mem._fetch import get_json_file
+from hf_mem._local import list_local_files, read_gguf_bytes, read_local_json, read_safetensors_header
 from hf_mem._types import KvCache
 from hf_mem._version import __version__
 from hf_mem.gguf.fetch import fetch_gguf_with_semaphore
-from hf_mem.gguf.metadata import GGUFDtype, GGUFMetadata, merge_shards
+from hf_mem.gguf.metadata import GGUFDtype, GGUFMetadata, merge_shards, parse_gguf_metadata
 from hf_mem.safetensors.fetch import fetch_modules_and_dense_metadata, fetch_safetensors_metadata
 from hf_mem.safetensors.kv_cache import compute_safetensors_kv_cache_size, resolve_kv_cache_dtype
 from hf_mem.safetensors.metadata import SafetensorsMetadata, parse_safetensors_metadata
@@ -178,6 +179,350 @@ async def arun(
     gguf_file: str | None = None,
     details: bool = False,
 ) -> Result:
+    # --- Local path detection ---
+    is_local = (os.sep in model_id or model_id.startswith(".")) and os.path.exists(model_id)
+
+    if is_local:
+        model_id = os.path.abspath(model_id)
+        revision = "local"
+
+        if os.path.isfile(model_id):
+            if model_id.endswith(".safetensors"):
+                raw_metadata = read_safetensors_header(model_id)
+                metadata = parse_safetensors_metadata({"Transformer": raw_metadata})
+                return Result(
+                    model_id=model_id,
+                    revision=revision,
+                    filename=None,
+                    memory=metadata.bytes_count,
+                    kv_cache=None,
+                    total_memory=metadata.bytes_count,
+                    details=details,
+                    safetensors=metadata,
+                )
+            elif model_id.endswith(".gguf"):
+                _kv_dtype = "F16" if kv_cache_dtype == "auto" else kv_cache_dtype
+                raw_bytes = read_gguf_bytes(model_id)
+                gguf_meta = parse_gguf_metadata(
+                    raw_metadata=raw_bytes,
+                    experimental=experimental,
+                    max_model_len=max_model_len,
+                    kv_cache_dtype=_kv_dtype,
+                    batch_size=batch_size,
+                )
+                filename = os.path.basename(model_id)
+                kv_bytes = gguf_meta.kv_cache.cache_size if gguf_meta.kv_cache is not None else None
+                return Result(
+                    model_id=model_id,
+                    revision=revision,
+                    filename=filename,
+                    memory=gguf_meta.bytes_count,
+                    kv_cache=kv_bytes,
+                    total_memory=gguf_meta.bytes_count + (kv_bytes or 0),
+                    details=details,
+                    gguf_files={filename: gguf_meta},
+                )
+            else:
+                raise RuntimeError(
+                    f"Unsupported local file type: {model_id}. Only .safetensors and .gguf files are supported."
+                )
+
+        elif not os.path.isdir(model_id):
+            raise RuntimeError(f"Local path exists but is neither a file nor a directory: {model_id}")
+
+        # --- Local directory path ---
+        file_paths = list_local_files(model_id)
+
+        gguf_paths = [f for f in file_paths if f.endswith(".gguf")]
+        has_safetensors = any(
+            f in ["model.safetensors", "model.safetensors.index.json", "model_index.json"] for f in file_paths
+        )
+        gguf = gguf_file is not None or (gguf_paths and not has_safetensors)
+
+        if not gguf and (has_safetensors and gguf_paths):
+            warnings.warn(
+                f"Both Safetensors and GGUF files have been found in {model_id}, if you want to estimate any of the GGUF file sizes, please use the `--gguf-file` flag with the path to the specific GGUF file. GGUF files found: {gguf_paths}."
+            )
+
+        if gguf:
+            if kv_cache_dtype not in GGUFDtype.__members__ and kv_cache_dtype != "auto":
+                raise RuntimeError(
+                    f"--kv-cache-dtype={kv_cache_dtype} not recognized for GGUF files. Valid options: {list(GGUFDtype.__members__.keys())} or `auto`."
+                )
+
+            if not gguf_paths:
+                raise RuntimeError(f"No GGUF files found in {model_id}.")
+
+            if gguf_file:
+                if prefix_match := re.match(r"(.+)-\d+-of-\d+\.gguf$", gguf_file):
+                    prefix = prefix_match.group(1)
+                    gguf_paths = [
+                        path
+                        for path in gguf_paths
+                        if re.match(rf"{re.escape(prefix)}-\d+-of-\d+\.gguf$", str(path))
+                    ]
+                else:
+                    gguf_paths = [path for path in gguf_paths if str(path).endswith(gguf_file)]
+                    if len(gguf_paths) > 1:
+                        raise RuntimeError(
+                            f"Multiple GGUF files named `{gguf_file}` found in {model_id}."
+                        )
+
+                if not gguf_paths:
+                    raise RuntimeError(f"No GGUF file matching `{gguf_file}` found in {model_id}.")
+
+            results: List[Tuple[str, GGUFMetadata, re.Match | None]] = []
+            for path in gguf_paths:
+                shard_pattern = _SHARD_PATTERN.match(str(path))
+                parse_kv_cache = experimental and (not shard_pattern or int(shard_pattern.group(2)) == 1)
+
+                _kv_dtype = "F16" if kv_cache_dtype == "auto" else kv_cache_dtype
+
+                raw_bytes = read_gguf_bytes(os.path.join(model_id, path))
+                gguf_meta = parse_gguf_metadata(
+                    raw_metadata=raw_bytes,
+                    experimental=parse_kv_cache,
+                    max_model_len=max_model_len,
+                    kv_cache_dtype=_kv_dtype,
+                    batch_size=batch_size,
+                )
+                results.append((str(path), gguf_meta, shard_pattern))
+
+            gguf_files_dict = _collect_gguf_results(results)
+
+            if gguf_file is not None:
+                single_filename = next(iter(gguf_files_dict))
+                gguf_meta = gguf_files_dict[single_filename]
+                kv_bytes = gguf_meta.kv_cache.cache_size if gguf_meta.kv_cache is not None else None
+                return Result(
+                    model_id=model_id,
+                    revision=revision,
+                    filename=single_filename,
+                    memory=gguf_meta.bytes_count,
+                    kv_cache=kv_bytes,
+                    total_memory=gguf_meta.bytes_count + (kv_bytes or 0),
+                    details=details,
+                    gguf_files=gguf_files_dict,
+                )
+            else:
+                memory_dict: Dict[str, int] = {fn: m.bytes_count for fn, m in gguf_files_dict.items()}
+                has_kv = any(m.kv_cache is not None for m in gguf_files_dict.values())
+                kv_dict: Union[Dict[str, int], None] = (
+                    {fn: m.kv_cache.cache_size for fn, m in gguf_files_dict.items() if m.kv_cache is not None}
+                    if has_kv
+                    else None
+                )
+                first_file = next(iter(gguf_files_dict))
+                warnings.warn(
+                    f"Multiple GGUF files found — `total_memory` is not set for multi-file results. "
+                    f"For a single-file estimate pass `gguf_file='{first_file}'` (library) or "
+                    f"`--gguf-file {first_file}` (CLI)."
+                )
+                return Result(
+                    model_id=model_id,
+                    revision=revision,
+                    filename=None,
+                    memory=memory_dict,
+                    kv_cache=kv_dict,
+                    total_memory=None,
+                    details=details,
+                    gguf_files=gguf_files_dict,
+                )
+
+        # --- Local safetensors directory ---
+        elif "model.safetensors" in file_paths:
+            raw_metadata = read_safetensors_header(os.path.join(model_id, "model.safetensors"))
+
+            if "config_sentence_transformers.json" in file_paths:
+                dense_metadata = {}
+                if "modules.json" in file_paths:
+                    modules = read_local_json(os.path.join(model_id, "modules.json"))
+                    for module in modules:
+                        if module.get("type") == "sentence_transformers.models.Dense" and "path" in module:
+                            path = module["path"]
+                            dense_metadata[path] = read_safetensors_header(
+                                os.path.join(model_id, path, "model.safetensors")
+                            )
+                raw_metadata = {"0_Transformer": raw_metadata, **dense_metadata}
+            else:
+                raw_metadata = {"Transformer": raw_metadata}
+
+            metadata = parse_safetensors_metadata(raw_metadata)
+
+        elif "model.safetensors.index.json" in file_paths:
+            files_index = read_local_json(os.path.join(model_id, "model.safetensors.index.json"))
+            shard_filenames = set(files_index["weight_map"].values())
+
+            raw_metadata_list = {}
+            for shard_filename in shard_filenames:
+                shard_metadata = read_safetensors_header(os.path.join(model_id, shard_filename))
+                raw_metadata_list.update(shard_metadata)
+
+            raw_metadata = raw_metadata_list
+
+            if "config_sentence_transformers.json" in file_paths:
+                dense_metadata = {}
+                if "modules.json" in file_paths:
+                    modules = read_local_json(os.path.join(model_id, "modules.json"))
+                    for module in modules:
+                        if module.get("type") == "sentence_transformers.models.Dense" and "path" in module:
+                            path = module["path"]
+                            dense_metadata[path] = read_safetensors_header(
+                                os.path.join(model_id, path, "model.safetensors")
+                            )
+                raw_metadata = {"0_Transformer": raw_metadata, **dense_metadata}
+            else:
+                raw_metadata = {"Transformer": raw_metadata}
+
+            metadata = parse_safetensors_metadata(raw_metadata)
+
+        elif "model_index.json" in file_paths:
+            files_index = read_local_json(os.path.join(model_id, "model_index.json"))
+            paths = {k for k, _ in files_index.items() if not k.startswith("_")}
+
+            raw_metadata = {}
+            for path in paths:
+                if os.path.join(path, "diffusion_pytorch_model.safetensors") in file_paths:
+                    raw_metadata[path] = read_safetensors_header(
+                        os.path.join(model_id, path, "diffusion_pytorch_model.safetensors")
+                    )
+                elif os.path.join(path, "model.safetensors") in file_paths:
+                    raw_metadata[path] = read_safetensors_header(
+                        os.path.join(model_id, path, "model.safetensors")
+                    )
+                elif os.path.join(path, "diffusion_pytorch_model.safetensors.index.json") in file_paths:
+                    idx = read_local_json(
+                        os.path.join(model_id, path, "diffusion_pytorch_model.safetensors.index.json")
+                    )
+                    component_metadata = {}
+                    for shard_filename in set(idx["weight_map"].values()):
+                        shard_metadata = read_safetensors_header(
+                            os.path.join(model_id, path, shard_filename)
+                        )
+                        component_metadata.update(shard_metadata)
+                    raw_metadata[path] = component_metadata
+                elif os.path.join(path, "model.safetensors.index.json") in file_paths:
+                    idx = read_local_json(
+                        os.path.join(model_id, path, "model.safetensors.index.json")
+                    )
+                    component_metadata = {}
+                    for shard_filename in set(idx["weight_map"].values()):
+                        shard_metadata = read_safetensors_header(
+                            os.path.join(model_id, path, shard_filename)
+                        )
+                        component_metadata.update(shard_metadata)
+                    raw_metadata[path] = component_metadata
+
+            metadata = parse_safetensors_metadata(raw_metadata)
+
+        else:
+            raise RuntimeError(
+                f"No recognized model files found in {model_id}. Expected any of: model.safetensors, "
+                "model.safetensors.index.json, model_index.json, or .gguf files."
+            )
+
+        # --- Local KV cache estimation (safetensors path) ---
+        kv_cache_cls: KvCache | None = None
+        if experimental and "config.json" in file_paths:
+            config: Dict[str, Any] = read_local_json(os.path.join(model_id, "config.json"))
+
+            if not any(
+                arch.__contains__("ForCausalLM") or arch.__contains__("ForConditionalGeneration")
+                for arch in config.get("architectures", [])
+            ):
+                warnings.warn(
+                    "`experimental=True` was set, but either `config.json` doesn't have the `architectures` key meaning that the model architecture cannot be inferred, or rather that it's neither `...ForCausalLM` nor `...ForConditionalGeneration`, meaning that the KV Cache estimation might not apply. If that's the case, then set `experimental=False` to suppress this warning."
+                )
+            else:
+                if (
+                    any(arch.__contains__("ForConditionalGeneration") for arch in config["architectures"])
+                    and "text_config" in config
+                ):
+                    warnings.warn(
+                        f"Given that `model_id={model_id}` is a `...ForConditionalGeneration` model, then the configuration from `config.json` will be retrieved from the key `text_config` instead."
+                    )
+                    text_config = config["text_config"]
+
+                    # On-demand HTTP client for referenced remote config
+                    if referenced_model := text_config.get("_name_or_path"):
+                        warnings.warn(
+                            f"The `text_config` contains `_name_or_path={referenced_model}`, so fetching the config from `{referenced_model}` to retrieve the required fields for KV cache estimation."
+                        )
+                        _headers: Dict[str, str] = {}
+                        if hf_token is not None:
+                            _headers["Authorization"] = f"Bearer {hf_token}"
+                        elif token := os.getenv("HF_TOKEN"):
+                            _headers["Authorization"] = f"Bearer {token}"
+                        elif "Authorization" not in _headers:
+                            _path = os.getenv("HF_HOME", ".cache/huggingface")
+                            _filename = (
+                                os.path.join(os.path.expanduser("~"), _path, "token")
+                                if not os.path.isabs(_path)
+                                else os.path.join(_path, "token")
+                            )
+                            if os.path.exists(_filename):
+                                with open(_filename, "r", encoding="utf-8") as f:
+                                    _headers["Authorization"] = f"Bearer {f.read().strip()}"
+
+                        _client = httpx.AsyncClient(
+                            timeout=httpx.Timeout(30.0),
+                            http2=True,
+                            follow_redirects=True,
+                        )
+                        referenced_url = f"https://huggingface.co/{referenced_model}/resolve/main/config.json"
+                        referenced_config = await get_json_file(_client, referenced_url, _headers)
+                        await _client.aclose()
+                        referenced_config.update(text_config)
+                        text_config = referenced_config
+
+                    config = text_config
+
+                if max_model_len is None:
+                    max_model_len = config.get(
+                        "max_position_embeddings",
+                        config.get("n_positions", config.get("max_seq_len", max_model_len)),
+                    )
+
+                if max_model_len is None:
+                    warnings.warn(
+                        "Either `max_model_len` was not set, is not available in `config.json` under any of `max_position_embeddings`, `n_positions`, or `max_seq_len` (in that order of priority), or both; so the memory required to fit the context length cannot be estimated."
+                    )
+                elif not all(k in config for k in {"hidden_size", "num_hidden_layers", "num_attention_heads"}):
+                    warnings.warn(
+                        f"`config.json` doesn't contain all the required keys `hidden_size`, `num_hidden_layers`, and `num_attention_heads`, but only {list(config.keys())}."
+                    )
+                else:
+                    cache_dtype = resolve_kv_cache_dtype(
+                        config=config,
+                        kv_cache_dtype=kv_cache_dtype,
+                        metadata=metadata,
+                        model_id=model_id,
+                    )
+                    kv_cache_cls = KvCache(
+                        max_model_len=max_model_len,
+                        cache_size=compute_safetensors_kv_cache_size(
+                            config=config,
+                            cache_dtype=cache_dtype,
+                            max_model_len=max_model_len,
+                            batch_size=batch_size,
+                        ),
+                        batch_size=batch_size,
+                        cache_dtype=cache_dtype,
+                    )
+
+        kv_bytes = kv_cache_cls.cache_size if kv_cache_cls is not None else None
+        return Result(
+            model_id=model_id,
+            revision=revision,
+            filename=None,
+            memory=metadata.bytes_count,
+            kv_cache=kv_bytes,
+            total_memory=metadata.bytes_count + (kv_bytes or 0),
+            details=details,
+            safetensors=metadata,
+            kv_cache_metadata=kv_cache_cls,
+        )
+
     headers: Dict[str, str] = {
         "User-Agent": f"hf-mem/{__version__}; id={uuid4()}; model_id={model_id}; revision={revision}"
     }

--- a/src/hf_mem/run.py
+++ b/src/hf_mem/run.py
@@ -365,7 +365,8 @@ async def arun(
     gguf_file: str | None = None,
     details: bool = False,
 ) -> Result:
-    is_local = (os.sep in model_id or model_id.startswith(".")) and os.path.exists(model_id)
+    # NOTE: Check for both os.sep and "/" so that forward-slash paths work on Windows
+    is_local = (os.sep in model_id or "/" in model_id or model_id.startswith(".")) and os.path.exists(model_id)
 
     if is_local:
         model_id = os.path.abspath(model_id)
@@ -482,15 +483,15 @@ async def arun(
 
             raw_metadata = {}
             for path in paths:
-                if os.path.join(path, "diffusion_pytorch_model.safetensors") in file_paths:
+                if f"{path}/diffusion_pytorch_model.safetensors" in file_paths:
                     raw_metadata[path] = read_safetensors_header(
                         os.path.join(model_id, path, "diffusion_pytorch_model.safetensors")
                     )
-                elif os.path.join(path, "model.safetensors") in file_paths:
+                elif f"{path}/model.safetensors" in file_paths:
                     raw_metadata[path] = read_safetensors_header(
                         os.path.join(model_id, path, "model.safetensors")
                     )
-                elif os.path.join(path, "diffusion_pytorch_model.safetensors.index.json") in file_paths:
+                elif f"{path}/diffusion_pytorch_model.safetensors.index.json" in file_paths:
                     idx = read_local_json(
                         os.path.join(model_id, path, "diffusion_pytorch_model.safetensors.index.json")
                     )
@@ -499,7 +500,7 @@ async def arun(
                         shard_metadata = read_safetensors_header(os.path.join(model_id, path, shard_filename))
                         component_metadata.update(shard_metadata)
                     raw_metadata[path] = component_metadata
-                elif os.path.join(path, "model.safetensors.index.json") in file_paths:
+                elif f"{path}/model.safetensors.index.json" in file_paths:
                     idx = read_local_json(os.path.join(model_id, path, "model.safetensors.index.json"))
                     component_metadata = {}
                     for shard_filename in set(idx["weight_map"].values()):

--- a/src/hf_mem/run.py
+++ b/src/hf_mem/run.py
@@ -4,7 +4,7 @@ import re
 import warnings
 from dataclasses import dataclass, field
 from functools import reduce
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Awaitable, Callable, Dict, List, Tuple, Union
 from uuid import uuid4
 
 import httpx
@@ -168,6 +168,190 @@ def _collect_gguf_results(
     return gguf_files
 
 
+def _resolve_hf_token(hf_token: str | None) -> Dict[str, str]:
+    """Resolve HuggingFace Hub token into an Authorization header dict.
+
+    Resolution order: explicit param -> HF_TOKEN env var -> $HF_HOME/token file.
+    Returns a dict with the Authorization key, or empty dict if no token found.
+    """
+    if hf_token is not None:
+        return {"Authorization": f"Bearer {hf_token}"}
+    if token := os.getenv("HF_TOKEN"):
+        return {"Authorization": f"Bearer {token}"}
+    hf_home = os.getenv("HF_HOME", ".cache/huggingface")
+    token_path = (
+        os.path.join(os.path.expanduser("~"), hf_home, "token")
+        if not os.path.isabs(hf_home)
+        else os.path.join(hf_home, "token")
+    )
+    if os.path.exists(token_path):
+        with open(token_path, "r", encoding="utf-8") as f:
+            return {"Authorization": f"Bearer {f.read().strip()}"}
+    return {}
+
+
+def _filter_gguf_paths(
+    gguf_paths: List[str],
+    gguf_file: str,
+    label: str,
+) -> List[str]:
+    """Filter GGUF file paths by the user's --gguf-file selection.
+
+    `label` provides context for error messages, e.g. "in /path/to/dir"
+    or "for model/id @ main".
+    """
+    # NOTE: Check if it's a sharded file (e.g. model-00001-of-00046.gguf)
+    if prefix_match := re.match(r"(.+)-\d+-of-\d+\.gguf$", gguf_file):
+        prefix = prefix_match.group(1)
+        gguf_paths = [
+            path for path in gguf_paths if re.match(rf"{re.escape(prefix)}-\d+-of-\d+\.gguf$", str(path))
+        ]
+    else:
+        gguf_paths = [path for path in gguf_paths if str(path).endswith(gguf_file)]
+        if len(gguf_paths) > 1:
+            raise RuntimeError(f"Multiple GGUF files named `{gguf_file}` found {label}.")
+
+    if not gguf_paths:
+        raise RuntimeError(f"No GGUF file matching `{gguf_file}` found {label}.")
+    return gguf_paths
+
+
+def _build_gguf_result(
+    model_id: str,
+    revision: str,
+    gguf_file: str | None,
+    gguf_files_dict: Dict[str, GGUFMetadata],
+    details: bool,
+) -> Result:
+    """Build a Result from a collected gguf_files_dict."""
+    if gguf_file is not None:
+        single_filename = next(iter(gguf_files_dict))
+        gguf_meta = gguf_files_dict[single_filename]
+        kv_bytes = gguf_meta.kv_cache.cache_size if gguf_meta.kv_cache is not None else None
+        return Result(
+            model_id=model_id,
+            revision=revision,
+            filename=single_filename,
+            memory=gguf_meta.bytes_count,
+            kv_cache=kv_bytes,
+            total_memory=gguf_meta.bytes_count + (kv_bytes or 0),
+            details=details,
+            gguf_files=gguf_files_dict,
+        )
+
+    memory_dict: Dict[str, int] = {fn: m.bytes_count for fn, m in gguf_files_dict.items()}
+    has_kv = any(m.kv_cache is not None for m in gguf_files_dict.values())
+    kv_dict: Union[Dict[str, int], None] = (
+        {fn: m.kv_cache.cache_size for fn, m in gguf_files_dict.items() if m.kv_cache is not None}
+        if has_kv
+        else None
+    )
+    first_file = next(iter(gguf_files_dict))
+    warnings.warn(
+        f"Multiple GGUF files found — `total_memory` is not set for multi-file results. "
+        f"For a single-file estimate pass `gguf_file='{first_file}'` (library) or "
+        f"`--gguf-file {first_file}` (CLI)."
+    )
+    return Result(
+        model_id=model_id,
+        revision=revision,
+        filename=None,
+        memory=memory_dict,
+        kv_cache=kv_dict,
+        total_memory=None,
+        details=details,
+        gguf_files=gguf_files_dict,
+    )
+
+
+def _wrap_sentence_transformer_metadata(
+    raw_metadata: Dict[str, Any],
+    dense_metadata: Dict[str, Any],
+    is_sentence_transformer: bool,
+) -> Dict[str, Any]:
+    """Wrap safetensors metadata with sentence-transformer or standard component naming."""
+    if is_sentence_transformer:
+        return {"0_Transformer": raw_metadata, **dense_metadata}
+    return {"Transformer": raw_metadata}
+
+
+async def _estimate_safetensors_kv_cache(
+    config: Dict[str, Any],
+    metadata: SafetensorsMetadata,
+    model_id: str,
+    max_model_len: int | None,
+    batch_size: int,
+    kv_cache_dtype: str,
+    get_referenced_config: Callable[[str], Awaitable[Dict[str, Any]]],
+) -> KvCache | None:
+    """Estimate KV cache size from a safetensors model's config.json.
+
+    `get_referenced_config` is an async callable that fetches a referenced model's
+    config.json when the text_config contains `_name_or_path`. This abstracts the
+    difference between the local path (one-off httpx client) and remote path (reuses
+    the existing client).
+    """
+    if not any(
+        "ForCausalLM" in arch or "ForConditionalGeneration" in arch for arch in config.get("architectures", [])
+    ):
+        warnings.warn(
+            "`experimental=True` was set, but either `config.json` doesn't have the `architectures` key meaning that the model architecture cannot be inferred, or rather that it's neither `...ForCausalLM` nor `...ForConditionalGeneration`, meaning that the KV Cache estimation might not apply. If that's the case, then set `experimental=False` to suppress this warning."
+        )
+        return None
+
+    if any("ForConditionalGeneration" in arch for arch in config["architectures"]) and "text_config" in config:
+        warnings.warn(
+            f"Given that `model_id={model_id}` is a `...ForConditionalGeneration` model, then the configuration from `config.json` will be retrieved from the key `text_config` instead."
+        )
+        text_config = config["text_config"]
+
+        if referenced_model := text_config.get("_name_or_path"):
+            warnings.warn(
+                f"The `text_config` contains `_name_or_path={referenced_model}`, so fetching the config from `{referenced_model}` to retrieve the required fields for KV cache estimation."
+            )
+            referenced_config = await get_referenced_config(referenced_model)
+            referenced_config.update(text_config)
+            text_config = referenced_config
+
+        config = text_config
+
+    if max_model_len is None:
+        max_model_len = config.get(
+            "max_position_embeddings",
+            config.get("n_positions", config.get("max_seq_len", max_model_len)),
+        )
+
+    if max_model_len is None:
+        warnings.warn(
+            "Either `max_model_len` was not set, is not available in `config.json` under any of `max_position_embeddings`, `n_positions`, or `max_seq_len` (in that order of priority), or both; so the memory required to fit the context length cannot be estimated."
+        )
+        return None
+
+    if not all(k in config for k in {"hidden_size", "num_hidden_layers", "num_attention_heads"}):
+        warnings.warn(
+            f"`config.json` doesn't contain all the required keys `hidden_size`, `num_hidden_layers`, and `num_attention_heads`, but only {list(config.keys())}."
+        )
+        return None
+
+    cache_dtype = resolve_kv_cache_dtype(
+        config=config,
+        kv_cache_dtype=kv_cache_dtype,
+        metadata=metadata,
+        model_id=model_id,
+    )
+    return KvCache(
+        max_model_len=max_model_len,
+        cache_size=compute_safetensors_kv_cache_size(
+            config=config,
+            cache_dtype=cache_dtype,
+            max_model_len=max_model_len,
+            batch_size=batch_size,
+        ),
+        batch_size=batch_size,
+        cache_dtype=cache_dtype,
+    )
+
+
 async def arun(
     model_id: str,
     revision: str = "main",
@@ -254,22 +438,7 @@ async def arun(
                 raise RuntimeError(f"No GGUF files found in {model_id}.")
 
             if gguf_file:
-                if prefix_match := re.match(r"(.+)-\d+-of-\d+\.gguf$", gguf_file):
-                    prefix = prefix_match.group(1)
-                    gguf_paths = [
-                        path
-                        for path in gguf_paths
-                        if re.match(rf"{re.escape(prefix)}-\d+-of-\d+\.gguf$", str(path))
-                    ]
-                else:
-                    gguf_paths = [path for path in gguf_paths if str(path).endswith(gguf_file)]
-                    if len(gguf_paths) > 1:
-                        raise RuntimeError(
-                            f"Multiple GGUF files named `{gguf_file}` found in {model_id}."
-                        )
-
-                if not gguf_paths:
-                    raise RuntimeError(f"No GGUF file matching `{gguf_file}` found in {model_id}.")
+                gguf_paths = _filter_gguf_paths(gguf_paths, gguf_file, f"in {model_id}")
 
             results: List[Tuple[str, GGUFMetadata, re.Match | None]] = []
             for path in gguf_paths:
@@ -290,62 +459,23 @@ async def arun(
 
             gguf_files_dict = _collect_gguf_results(results)
 
-            if gguf_file is not None:
-                single_filename = next(iter(gguf_files_dict))
-                gguf_meta = gguf_files_dict[single_filename]
-                kv_bytes = gguf_meta.kv_cache.cache_size if gguf_meta.kv_cache is not None else None
-                return Result(
-                    model_id=model_id,
-                    revision=revision,
-                    filename=single_filename,
-                    memory=gguf_meta.bytes_count,
-                    kv_cache=kv_bytes,
-                    total_memory=gguf_meta.bytes_count + (kv_bytes or 0),
-                    details=details,
-                    gguf_files=gguf_files_dict,
-                )
-            else:
-                memory_dict: Dict[str, int] = {fn: m.bytes_count for fn, m in gguf_files_dict.items()}
-                has_kv = any(m.kv_cache is not None for m in gguf_files_dict.values())
-                kv_dict: Union[Dict[str, int], None] = (
-                    {fn: m.kv_cache.cache_size for fn, m in gguf_files_dict.items() if m.kv_cache is not None}
-                    if has_kv
-                    else None
-                )
-                first_file = next(iter(gguf_files_dict))
-                warnings.warn(
-                    f"Multiple GGUF files found — `total_memory` is not set for multi-file results. "
-                    f"For a single-file estimate pass `gguf_file='{first_file}'` (library) or "
-                    f"`--gguf-file {first_file}` (CLI)."
-                )
-                return Result(
-                    model_id=model_id,
-                    revision=revision,
-                    filename=None,
-                    memory=memory_dict,
-                    kv_cache=kv_dict,
-                    total_memory=None,
-                    details=details,
-                    gguf_files=gguf_files_dict,
-                )
+            return _build_gguf_result(model_id, revision, gguf_file, gguf_files_dict, details)
 
         # --- Local safetensors directory ---
         elif "model.safetensors" in file_paths:
             raw_metadata = read_safetensors_header(os.path.join(model_id, "model.safetensors"))
 
-            if "config_sentence_transformers.json" in file_paths:
-                dense_metadata = {}
-                if "modules.json" in file_paths:
-                    modules = read_local_json(os.path.join(model_id, "modules.json"))
-                    for module in modules:
-                        if module.get("type") == "sentence_transformers.models.Dense" and "path" in module:
-                            path = module["path"]
-                            dense_metadata[path] = read_safetensors_header(
-                                os.path.join(model_id, path, "model.safetensors")
-                            )
-                raw_metadata = {"0_Transformer": raw_metadata, **dense_metadata}
-            else:
-                raw_metadata = {"Transformer": raw_metadata}
+            is_st = "config_sentence_transformers.json" in file_paths
+            dense_metadata = {}
+            if is_st and "modules.json" in file_paths:
+                modules = read_local_json(os.path.join(model_id, "modules.json"))
+                for module in modules:
+                    if module.get("type") == "sentence_transformers.models.Dense" and "path" in module:
+                        dense_path = module["path"]
+                        dense_metadata[dense_path] = read_safetensors_header(
+                            os.path.join(model_id, dense_path, "model.safetensors")
+                        )
+            raw_metadata = _wrap_sentence_transformer_metadata(raw_metadata, dense_metadata, is_st)
 
             metadata = parse_safetensors_metadata(raw_metadata)
 
@@ -360,19 +490,17 @@ async def arun(
 
             raw_metadata = raw_metadata_list
 
-            if "config_sentence_transformers.json" in file_paths:
-                dense_metadata = {}
-                if "modules.json" in file_paths:
-                    modules = read_local_json(os.path.join(model_id, "modules.json"))
-                    for module in modules:
-                        if module.get("type") == "sentence_transformers.models.Dense" and "path" in module:
-                            path = module["path"]
-                            dense_metadata[path] = read_safetensors_header(
-                                os.path.join(model_id, path, "model.safetensors")
-                            )
-                raw_metadata = {"0_Transformer": raw_metadata, **dense_metadata}
-            else:
-                raw_metadata = {"Transformer": raw_metadata}
+            is_st = "config_sentence_transformers.json" in file_paths
+            dense_metadata = {}
+            if is_st and "modules.json" in file_paths:
+                modules = read_local_json(os.path.join(model_id, "modules.json"))
+                for module in modules:
+                    if module.get("type") == "sentence_transformers.models.Dense" and "path" in module:
+                        dense_path = module["path"]
+                        dense_metadata[dense_path] = read_safetensors_header(
+                            os.path.join(model_id, dense_path, "model.safetensors")
+                        )
+            raw_metadata = _wrap_sentence_transformer_metadata(raw_metadata, dense_metadata, is_st)
 
             metadata = parse_safetensors_metadata(raw_metadata)
 
@@ -396,20 +524,14 @@ async def arun(
                     )
                     component_metadata = {}
                     for shard_filename in set(idx["weight_map"].values()):
-                        shard_metadata = read_safetensors_header(
-                            os.path.join(model_id, path, shard_filename)
-                        )
+                        shard_metadata = read_safetensors_header(os.path.join(model_id, path, shard_filename))
                         component_metadata.update(shard_metadata)
                     raw_metadata[path] = component_metadata
                 elif os.path.join(path, "model.safetensors.index.json") in file_paths:
-                    idx = read_local_json(
-                        os.path.join(model_id, path, "model.safetensors.index.json")
-                    )
+                    idx = read_local_json(os.path.join(model_id, path, "model.safetensors.index.json"))
                     component_metadata = {}
                     for shard_filename in set(idx["weight_map"].values()):
-                        shard_metadata = read_safetensors_header(
-                            os.path.join(model_id, path, shard_filename)
-                        )
+                        shard_metadata = read_safetensors_header(os.path.join(model_id, path, shard_filename))
                         component_metadata.update(shard_metadata)
                     raw_metadata[path] = component_metadata
 
@@ -426,89 +548,31 @@ async def arun(
         if experimental and "config.json" in file_paths:
             config: Dict[str, Any] = read_local_json(os.path.join(model_id, "config.json"))
 
-            if not any(
-                arch.__contains__("ForCausalLM") or arch.__contains__("ForConditionalGeneration")
-                for arch in config.get("architectures", [])
-            ):
-                warnings.warn(
-                    "`experimental=True` was set, but either `config.json` doesn't have the `architectures` key meaning that the model architecture cannot be inferred, or rather that it's neither `...ForCausalLM` nor `...ForConditionalGeneration`, meaning that the KV Cache estimation might not apply. If that's the case, then set `experimental=False` to suppress this warning."
+            async def _get_referenced_config(referenced_model: str) -> Dict[str, Any]:
+                # NOTE: Local path still needs to fetch referenced configs from the Hub,
+                # as _name_or_path refers to a different model (e.g. the text backbone
+                # of a conditional generation model)
+                _headers = _resolve_hf_token(hf_token)
+                _client = httpx.AsyncClient(
+                    timeout=httpx.Timeout(30.0),
+                    http2=True,
+                    follow_redirects=True,
                 )
-            else:
-                if (
-                    any(arch.__contains__("ForConditionalGeneration") for arch in config["architectures"])
-                    and "text_config" in config
-                ):
-                    warnings.warn(
-                        f"Given that `model_id={model_id}` is a `...ForConditionalGeneration` model, then the configuration from `config.json` will be retrieved from the key `text_config` instead."
-                    )
-                    text_config = config["text_config"]
+                try:
+                    _url = f"https://huggingface.co/{referenced_model}/resolve/main/config.json"
+                    return await get_json_file(_client, _url, _headers)
+                finally:
+                    await _client.aclose()
 
-                    # On-demand HTTP client for referenced remote config
-                    if referenced_model := text_config.get("_name_or_path"):
-                        warnings.warn(
-                            f"The `text_config` contains `_name_or_path={referenced_model}`, so fetching the config from `{referenced_model}` to retrieve the required fields for KV cache estimation."
-                        )
-                        _headers: Dict[str, str] = {}
-                        if hf_token is not None:
-                            _headers["Authorization"] = f"Bearer {hf_token}"
-                        elif token := os.getenv("HF_TOKEN"):
-                            _headers["Authorization"] = f"Bearer {token}"
-                        elif "Authorization" not in _headers:
-                            _path = os.getenv("HF_HOME", ".cache/huggingface")
-                            _filename = (
-                                os.path.join(os.path.expanduser("~"), _path, "token")
-                                if not os.path.isabs(_path)
-                                else os.path.join(_path, "token")
-                            )
-                            if os.path.exists(_filename):
-                                with open(_filename, "r", encoding="utf-8") as f:
-                                    _headers["Authorization"] = f"Bearer {f.read().strip()}"
-
-                        _client = httpx.AsyncClient(
-                            timeout=httpx.Timeout(30.0),
-                            http2=True,
-                            follow_redirects=True,
-                        )
-                        referenced_url = f"https://huggingface.co/{referenced_model}/resolve/main/config.json"
-                        referenced_config = await get_json_file(_client, referenced_url, _headers)
-                        await _client.aclose()
-                        referenced_config.update(text_config)
-                        text_config = referenced_config
-
-                    config = text_config
-
-                if max_model_len is None:
-                    max_model_len = config.get(
-                        "max_position_embeddings",
-                        config.get("n_positions", config.get("max_seq_len", max_model_len)),
-                    )
-
-                if max_model_len is None:
-                    warnings.warn(
-                        "Either `max_model_len` was not set, is not available in `config.json` under any of `max_position_embeddings`, `n_positions`, or `max_seq_len` (in that order of priority), or both; so the memory required to fit the context length cannot be estimated."
-                    )
-                elif not all(k in config for k in {"hidden_size", "num_hidden_layers", "num_attention_heads"}):
-                    warnings.warn(
-                        f"`config.json` doesn't contain all the required keys `hidden_size`, `num_hidden_layers`, and `num_attention_heads`, but only {list(config.keys())}."
-                    )
-                else:
-                    cache_dtype = resolve_kv_cache_dtype(
-                        config=config,
-                        kv_cache_dtype=kv_cache_dtype,
-                        metadata=metadata,
-                        model_id=model_id,
-                    )
-                    kv_cache_cls = KvCache(
-                        max_model_len=max_model_len,
-                        cache_size=compute_safetensors_kv_cache_size(
-                            config=config,
-                            cache_dtype=cache_dtype,
-                            max_model_len=max_model_len,
-                            batch_size=batch_size,
-                        ),
-                        batch_size=batch_size,
-                        cache_dtype=cache_dtype,
-                    )
+            kv_cache_cls = await _estimate_safetensors_kv_cache(
+                config=config,
+                metadata=metadata,
+                model_id=model_id,
+                max_model_len=max_model_len,
+                batch_size=batch_size,
+                kv_cache_dtype=kv_cache_dtype,
+                get_referenced_config=_get_referenced_config,
+            )
 
         kv_bytes = kv_cache_cls.cache_size if kv_cache_cls is not None else None
         return Result(
@@ -524,28 +588,9 @@ async def arun(
         )
 
     headers: Dict[str, str] = {
-        "User-Agent": f"hf-mem/{__version__}; id={uuid4()}; model_id={model_id}; revision={revision}"
+        "User-Agent": f"hf-mem/{__version__}; id={uuid4()}; model_id={model_id}; revision={revision}",
+        **_resolve_hf_token(hf_token),
     }
-
-    # NOTE: The Hugging Face Hub token is not only required to read the files for gated / private models, but also
-    # to benefit from more generous request tiers to the Hub
-    if hf_token is not None:
-        headers["Authorization"] = f"Bearer {hf_token}"
-    # NOTE: Read from `HF_TOKEN` if provided
-    elif token := os.getenv("HF_TOKEN"):
-        headers["Authorization"] = f"Bearer {token}"
-    # NOTE: If neither the `--hf-token` is provided nor the `HF_TOKEN` is set, then fallback to reading from
-    # `$HF_HOME/token`
-    elif "Authorization" not in headers:
-        path = os.getenv("HF_HOME", ".cache/huggingface")
-        filename = (
-            os.path.join(os.path.expanduser("~"), path, "token")
-            if not os.path.isabs(path)
-            else os.path.join(path, "token")
-        )
-        if os.path.exists(filename):
-            with open(filename, "r", encoding="utf-8") as f:
-                headers["Authorization"] = f"Bearer {f.read().strip()}"
 
     client = httpx.AsyncClient(
         limits=httpx.Limits(
@@ -585,23 +630,7 @@ async def arun(
             raise RuntimeError(f"No GGUF files found for {model_id} @ {revision}.")
 
         if gguf_file:
-            # NOTE: Check if it's a sharded file (e.g. model-00001-of-00046.gguf)
-            if prefix_match := re.match(r"(.+)-\d+-of-\d+\.gguf$", gguf_file):
-                prefix = prefix_match.group(1)
-                gguf_paths = [
-                    path
-                    for path in gguf_paths
-                    if re.match(rf"{re.escape(prefix)}-\d+-of-\d+\.gguf$", str(path))
-                ]
-            else:
-                gguf_paths = [path for path in gguf_paths if str(path).endswith(gguf_file)]
-                if len(gguf_paths) > 1:
-                    raise RuntimeError(
-                        f"Multiple GGUF files named `{gguf_file}` found for {model_id} @ {revision}."
-                    )
-
-            if not gguf_paths:
-                raise RuntimeError(f"No GGUF file matching `{gguf_file}` found for {model_id} @ {revision}.")
+            gguf_paths = _filter_gguf_paths(gguf_paths, gguf_file, f"for {model_id} @ {revision}")
 
         semaphore = asyncio.Semaphore(MAX_CONCURRENCY)
         tasks = []
@@ -630,64 +659,23 @@ async def arun(
         gguf_files_dict = _collect_gguf_results(await asyncio.gather(*tasks))
         await client.aclose()
 
-        if gguf_file is not None:
-            single_filename = next(iter(gguf_files_dict))
-            gguf_meta = gguf_files_dict[single_filename]
-            kv_bytes = gguf_meta.kv_cache.cache_size if gguf_meta.kv_cache is not None else None
-            return Result(
-                model_id=model_id,
-                revision=revision,
-                filename=single_filename,
-                memory=gguf_meta.bytes_count,
-                kv_cache=kv_bytes,
-                total_memory=gguf_meta.bytes_count + (kv_bytes or 0),
-                details=details,
-                gguf_files=gguf_files_dict,
-            )
-        else:
-            memory_dict: Dict[str, int] = {fn: m.bytes_count for fn, m in gguf_files_dict.items()}
-            has_kv = any(m.kv_cache is not None for m in gguf_files_dict.values())
-            kv_dict: Union[Dict[str, int], None] = (
-                {fn: m.kv_cache.cache_size for fn, m in gguf_files_dict.items() if m.kv_cache is not None}
-                if has_kv
-                else None
-            )
-            first_file = next(iter(gguf_files_dict))
-            warnings.warn(
-                f"Multiple GGUF files found — `total_memory` is not set for multi-file results. "
-                f"For a single-file estimate pass `gguf_file='{first_file}'` (library) or "
-                f"`--gguf-file {first_file}` (CLI)."
-            )
-            return Result(
-                model_id=model_id,
-                revision=revision,
-                filename=None,
-                memory=memory_dict,
-                kv_cache=kv_dict,
-                total_memory=None,
-                details=details,
-                gguf_files=gguf_files_dict,
-            )
+        return _build_gguf_result(model_id, revision, gguf_file, gguf_files_dict, details)
 
     if "model.safetensors" in file_paths:
         url = f"https://huggingface.co/{model_id}/resolve/{revision}/model.safetensors"
         raw_metadata = await fetch_safetensors_metadata(client=client, url=url, headers=headers)
 
-        if "config_sentence_transformers.json" in file_paths:
-            dense_metadata = (
-                {}
-                if "modules.json" not in file_paths
-                else await fetch_modules_and_dense_metadata(
-                    client=client,
-                    url=f"https://huggingface.co/{model_id}/resolve/{revision}",
-                    headers=headers,
-                )
+        is_st = "config_sentence_transformers.json" in file_paths
+        dense_metadata = (
+            {}
+            if not is_st or "modules.json" not in file_paths
+            else await fetch_modules_and_dense_metadata(
+                client=client,
+                url=f"https://huggingface.co/{model_id}/resolve/{revision}",
+                headers=headers,
             )
-            raw_metadata = {"0_Transformer": raw_metadata, **dense_metadata}
-        else:
-            # NOTE: If the model is a transformers model, then we simply set the component name to `Transformer`, to
-            # make sure that we provide the expected input to the `parse_safetensors_metadata`
-            raw_metadata = {"Transformer": raw_metadata}
+        )
+        raw_metadata = _wrap_sentence_transformer_metadata(raw_metadata, dense_metadata, is_st)
 
         metadata = parse_safetensors_metadata(raw_metadata=raw_metadata)
 
@@ -713,19 +701,17 @@ async def arun(
         )
         raw_metadata = reduce(lambda acc, m: acc | m, metadata_list, {})
 
-        if "config_sentence_transformers.json" in file_paths:
-            dense_metadata = (
-                {}
-                if "modules.json" not in file_paths
-                else await fetch_modules_and_dense_metadata(
-                    client=client,
-                    url=f"https://huggingface.co/{model_id}/resolve/{revision}",
-                    headers=headers,
-                )
+        is_st = "config_sentence_transformers.json" in file_paths
+        dense_metadata = (
+            {}
+            if not is_st or "modules.json" not in file_paths
+            else await fetch_modules_and_dense_metadata(
+                client=client,
+                url=f"https://huggingface.co/{model_id}/resolve/{revision}",
+                headers=headers,
             )
-            raw_metadata = {"0_Transformer": raw_metadata, **dense_metadata}
-        else:
-            raw_metadata = {"Transformer": raw_metadata}
+        )
+        raw_metadata = _wrap_sentence_transformer_metadata(raw_metadata, dense_metadata, is_st)
 
         metadata = parse_safetensors_metadata(raw_metadata=raw_metadata)
 
@@ -793,66 +779,19 @@ async def arun(
         url = f"https://huggingface.co/{model_id}/resolve/{revision}/config.json"
         config: Dict[str, Any] = await get_json_file(client, url, headers)
 
-        if not any(
-            arch.__contains__("ForCausalLM") or arch.__contains__("ForConditionalGeneration")
-            for arch in config.get("architectures", [])
-        ):
-            warnings.warn(
-                "`experimental=True` was set, but either `config.json` doesn't have the `architectures` key meaning that the model architecture cannot be inferred, or rather that it's neither `...ForCausalLM` nor `...ForConditionalGeneration`, meaning that the KV Cache estimation might not apply. If that's the case, then set `experimental=False` to suppress this warning."
-            )
-        else:
-            if (
-                any(arch.__contains__("ForConditionalGeneration") for arch in config["architectures"])
-                and "text_config" in config
-            ):
-                warnings.warn(
-                    f"Given that `model_id={model_id}` is a `...ForConditionalGeneration` model, then the configuration from `config.json` will be retrieved from the key `text_config` instead."
-                )
-                text_config = config["text_config"]
+        async def _get_referenced_config(referenced_model: str) -> Dict[str, Any]:
+            _url = f"https://huggingface.co/{referenced_model}/resolve/{revision}/config.json"
+            return await get_json_file(client, _url, headers)
 
-                if referenced_model := text_config.get("_name_or_path"):
-                    referenced_url = f"https://huggingface.co/{referenced_model}/resolve/{revision}/config.json"
-                    warnings.warn(
-                        f"The `text_config` contains `_name_or_path={referenced_model}`, so fetching the config from `{referenced_model}` to retrieve the required fields for KV cache estimation."
-                    )
-                    referenced_config = await get_json_file(client, referenced_url, headers)
-                    referenced_config.update(text_config)
-                    text_config = referenced_config
-
-                config = text_config
-
-            if max_model_len is None:
-                max_model_len = config.get(
-                    "max_position_embeddings",
-                    config.get("n_positions", config.get("max_seq_len", max_model_len)),
-                )
-
-            if max_model_len is None:
-                warnings.warn(
-                    "Either `max_model_len` was not set, is not available in `config.json` under any of `max_position_embeddings`, `n_positions`, or `max_seq_len` (in that order of priority), or both; so the memory required to fit the context length cannot be estimated."
-                )
-            elif not all(k in config for k in {"hidden_size", "num_hidden_layers", "num_attention_heads"}):
-                warnings.warn(
-                    f"`config.json` doesn't contain all the required keys `hidden_size`, `num_hidden_layers`, and `num_attention_heads`, but only {list(config.keys())}."
-                )
-            else:
-                cache_dtype = resolve_kv_cache_dtype(
-                    config=config,
-                    kv_cache_dtype=kv_cache_dtype,
-                    metadata=metadata,
-                    model_id=model_id,
-                )
-                kv_cache_cls = KvCache(
-                    max_model_len=max_model_len,
-                    cache_size=compute_safetensors_kv_cache_size(
-                        config=config,
-                        cache_dtype=cache_dtype,
-                        max_model_len=max_model_len,
-                        batch_size=batch_size,
-                    ),
-                    batch_size=batch_size,
-                    cache_dtype=cache_dtype,
-                )
+        kv_cache_cls = await _estimate_safetensors_kv_cache(
+            config=config,
+            metadata=metadata,
+            model_id=model_id,
+            max_model_len=max_model_len,
+            batch_size=batch_size,
+            kv_cache_dtype=kv_cache_dtype,
+            get_referenced_config=_get_referenced_config,
+        )
 
     await client.aclose()
     kv_bytes = kv_cache_cls.cache_size if kv_cache_cls is not None else None

--- a/src/hf_mem/run.py
+++ b/src/hf_mem/run.py
@@ -169,11 +169,6 @@ def _collect_gguf_results(
 
 
 def _resolve_hf_token(hf_token: str | None) -> Dict[str, str]:
-    """Resolve HuggingFace Hub token into an Authorization header dict.
-
-    Resolution order: explicit param -> HF_TOKEN env var -> $HF_HOME/token file.
-    Returns a dict with the Authorization key, or empty dict if no token found.
-    """
     if hf_token is not None:
         return {"Authorization": f"Bearer {hf_token}"}
     if token := os.getenv("HF_TOKEN"):
@@ -195,12 +190,6 @@ def _filter_gguf_paths(
     gguf_file: str,
     label: str,
 ) -> List[str]:
-    """Filter GGUF file paths by the user's --gguf-file selection.
-
-    `label` provides context for error messages, e.g. "in /path/to/dir"
-    or "for model/id @ main".
-    """
-    # NOTE: Check if it's a sharded file (e.g. model-00001-of-00046.gguf)
     if prefix_match := re.match(r"(.+)-\d+-of-\d+\.gguf$", gguf_file):
         prefix = prefix_match.group(1)
         gguf_paths = [
@@ -223,7 +212,6 @@ def _build_gguf_result(
     gguf_files_dict: Dict[str, GGUFMetadata],
     details: bool,
 ) -> Result:
-    """Build a Result from a collected gguf_files_dict."""
     if gguf_file is not None:
         single_filename = next(iter(gguf_files_dict))
         gguf_meta = gguf_files_dict[single_filename]
@@ -269,10 +257,27 @@ def _wrap_sentence_transformer_metadata(
     dense_metadata: Dict[str, Any],
     is_sentence_transformer: bool,
 ) -> Dict[str, Any]:
-    """Wrap safetensors metadata with sentence-transformer or standard component naming."""
     if is_sentence_transformer:
         return {"0_Transformer": raw_metadata, **dense_metadata}
     return {"Transformer": raw_metadata}
+
+
+def _wrap_local_safetensors_metadata(
+    raw_metadata: Dict[str, Any],
+    model_id: str,
+    file_paths: List[str],
+) -> Dict[str, Any]:
+    is_st = "config_sentence_transformers.json" in file_paths
+    dense_metadata: Dict[str, Any] = {}
+    if is_st and "modules.json" in file_paths:
+        modules = read_local_json(os.path.join(model_id, "modules.json"))
+        for module in modules:
+            if module.get("type") == "sentence_transformers.models.Dense" and "path" in module:
+                dense_path = module["path"]
+                dense_metadata[dense_path] = read_safetensors_header(
+                    os.path.join(model_id, dense_path, "model.safetensors")
+                )
+    return _wrap_sentence_transformer_metadata(raw_metadata, dense_metadata, is_st)
 
 
 async def _estimate_safetensors_kv_cache(
@@ -284,13 +289,6 @@ async def _estimate_safetensors_kv_cache(
     kv_cache_dtype: str,
     get_referenced_config: Callable[[str], Awaitable[Dict[str, Any]]],
 ) -> KvCache | None:
-    """Estimate KV cache size from a safetensors model's config.json.
-
-    `get_referenced_config` is an async callable that fetches a referenced model's
-    config.json when the text_config contains `_name_or_path`. This abstracts the
-    difference between the local path (one-off httpx client) and remote path (reuses
-    the existing client).
-    """
     if not any(
         "ForCausalLM" in arch or "ForConditionalGeneration" in arch for arch in config.get("architectures", [])
     ):
@@ -367,7 +365,6 @@ async def arun(
     gguf_file: str | None = None,
     details: bool = False,
 ) -> Result:
-    # --- Local path detection ---
     is_local = (os.sep in model_id or model_id.startswith(".")) and os.path.exists(model_id)
 
     if is_local:
@@ -418,10 +415,9 @@ async def arun(
         elif not os.path.isdir(model_id):
             raise RuntimeError(f"Local path exists but is neither a file nor a directory: {model_id}")
 
-        # --- Local directory path ---
         file_paths = list_local_files(model_id)
 
-        gguf_paths = [f for f in file_paths if f.endswith(".gguf")]
+        gguf_paths = [f for f in file_paths if f.endswith(".gguf") and "mmproj-" not in f]
         has_safetensors = any(
             f in ["model.safetensors", "model.safetensors.index.json", "model_index.json"] for f in file_paths
         )
@@ -444,13 +440,11 @@ async def arun(
             if gguf_file:
                 gguf_paths = _filter_gguf_paths(gguf_paths, gguf_file, f"in {model_id}")
 
+            _kv_dtype = "F16" if kv_cache_dtype == "auto" else kv_cache_dtype
             results: List[Tuple[str, GGUFMetadata, re.Match | None]] = []
             for path in gguf_paths:
                 shard_pattern = _SHARD_PATTERN.match(str(path))
                 parse_kv_cache = experimental and (not shard_pattern or int(shard_pattern.group(2)) == 1)
-
-                _kv_dtype = "F16" if kv_cache_dtype == "auto" else kv_cache_dtype
-
                 raw_bytes = read_gguf_bytes(os.path.join(model_id, path))
                 gguf_meta = parse_gguf_metadata(
                     raw_metadata=raw_bytes,
@@ -465,47 +459,21 @@ async def arun(
 
             return _build_gguf_result(model_id, revision, gguf_file, gguf_files_dict, details)
 
-        # --- Local safetensors directory ---
         elif "model.safetensors" in file_paths:
             raw_metadata = read_safetensors_header(os.path.join(model_id, "model.safetensors"))
-
-            is_st = "config_sentence_transformers.json" in file_paths
-            dense_metadata = {}
-            if is_st and "modules.json" in file_paths:
-                modules = read_local_json(os.path.join(model_id, "modules.json"))
-                for module in modules:
-                    if module.get("type") == "sentence_transformers.models.Dense" and "path" in module:
-                        dense_path = module["path"]
-                        dense_metadata[dense_path] = read_safetensors_header(
-                            os.path.join(model_id, dense_path, "model.safetensors")
-                        )
-            raw_metadata = _wrap_sentence_transformer_metadata(raw_metadata, dense_metadata, is_st)
-
+            raw_metadata = _wrap_local_safetensors_metadata(raw_metadata, model_id, file_paths)
             metadata = parse_safetensors_metadata(raw_metadata)
 
         elif "model.safetensors.index.json" in file_paths:
             files_index = read_local_json(os.path.join(model_id, "model.safetensors.index.json"))
             shard_filenames = set(files_index["weight_map"].values())
 
-            raw_metadata_list = {}
+            raw_metadata = {}
             for shard_filename in shard_filenames:
                 shard_metadata = read_safetensors_header(os.path.join(model_id, shard_filename))
-                raw_metadata_list.update(shard_metadata)
+                raw_metadata.update(shard_metadata)
 
-            raw_metadata = raw_metadata_list
-
-            is_st = "config_sentence_transformers.json" in file_paths
-            dense_metadata = {}
-            if is_st and "modules.json" in file_paths:
-                modules = read_local_json(os.path.join(model_id, "modules.json"))
-                for module in modules:
-                    if module.get("type") == "sentence_transformers.models.Dense" and "path" in module:
-                        dense_path = module["path"]
-                        dense_metadata[dense_path] = read_safetensors_header(
-                            os.path.join(model_id, dense_path, "model.safetensors")
-                        )
-            raw_metadata = _wrap_sentence_transformer_metadata(raw_metadata, dense_metadata, is_st)
-
+            raw_metadata = _wrap_local_safetensors_metadata(raw_metadata, model_id, file_paths)
             metadata = parse_safetensors_metadata(raw_metadata)
 
         elif "model_index.json" in file_paths:
@@ -547,15 +515,11 @@ async def arun(
                 "model.safetensors.index.json, model_index.json, or .gguf files."
             )
 
-        # --- Local KV cache estimation (safetensors path) ---
         kv_cache_cls: KvCache | None = None
         if experimental and "config.json" in file_paths:
             config: Dict[str, Any] = read_local_json(os.path.join(model_id, "config.json"))
 
             async def _get_referenced_config(referenced_model: str) -> Dict[str, Any]:
-                # NOTE: Local path still needs to fetch referenced configs from the Hub,
-                # as _name_or_path refers to a different model (e.g. the text backbone
-                # of a conditional generation model)
                 _headers = _resolve_hf_token(hf_token)
                 _client = httpx.AsyncClient(
                     timeout=httpx.Timeout(30.0),

--- a/src/hf_mem/safetensors/print.py
+++ b/src/hf_mem/safetensors/print.py
@@ -5,6 +5,7 @@ from hf_mem._print import (
     MAX_DATA_LEN,
     MAX_NAME_LEN,
     _bytes_to_gib,
+    _format_model_label,
     _format_short_number,
     _make_bar,
     _print_centered,
@@ -27,7 +28,7 @@ def print_safetensors_report(
 
     centered_rows = [
         "INFERENCE MEMORY ESTIMATE FOR",
-        f"https://hf.co/{model_id} @ {revision}",
+        _format_model_label(model_id, revision),
     ]
     if kv_cache:
         centered_rows.append(f"w/ max-model-len={kv_cache.max_model_len}, batch-size={kv_cache.batch_size}")
@@ -78,7 +79,7 @@ def print_safetensors_report(
 
     _print_header(current_len, badge=f"hf-mem v{__version__}")
     _print_centered("INFERENCE MEMORY ESTIMATE FOR", current_len)
-    _print_centered(f"https://hf.co/{model_id} @ {revision}", current_len)
+    _print_centered(_format_model_label(model_id, revision), current_len)
     if kv_cache:
         _print_centered(
             f"w/ max-model-len={kv_cache.max_model_len}, batch-size={kv_cache.batch_size}",


### PR DESCRIPTION
## Summary

Fixes #2 
Add support for local file and directory paths in `--model-id`, so users can estimate memory for models already on disk without fetching from the Hub.

### Local file support (`4d25c71`)

- **Auto-detection**: local paths are detected when the value contains a path separator or starts with `.` and exists on disk. Use `./` prefix for relative paths.
- **Safetensors**: supports all layouts locally — single file, sharded (`model.safetensors.index.json`), Diffusers (`model_index.json`), and Sentence Transformers (with Dense module detection via `modules.json`).
- **GGUF**: supports single files, multi-file directories, and sharded models. Shard merging and `--gguf-file` filtering work identically to the remote path.
- **KV cache estimation**: works with local `config.json`, including on-demand HTTP fetch for referenced configs when `text_config._name_or_path` points to a different Hub model (e.g. conditional generation models).
- **New module**: `src/hf_mem/_local.py` with local I/O functions (`read_safetensors_header`, `read_local_json`, `read_gguf_bytes`, `list_local_files`) that return the same data shapes as the HTTP fetches, so all existing parsing and display code is reused unchanged.
- **CLI**: `--model-id` help text updated to document local path usage.

### Refactor: deduplicate local/remote paths (`297aec9`)

The initial local support duplicated ~340 lines of logic from the remote (Hub) code path. Extracted 5 shared private helpers in `run.py` to eliminate the duplication:

- **`_resolve_hf_token`**: unifies 3 copies of HF token resolution (explicit param → `HF_TOKEN` env → `$HF_HOME/token` file). Also removes a dead-code guard (`elif "Authorization" not in headers` on a freshly-created dict).
- **`_filter_gguf_paths`**: unifies 2 copies of `--gguf-file` path filtering (shard prefix matching, exact suffix matching, error messages). Error context parameterized via a `label` string.
- **`_build_gguf_result`**: unifies 2 copies of `Result` construction from a `gguf_files_dict` (single-file and multi-file sub-paths).
- **`_wrap_sentence_transformer_metadata`**: unifies 4 occurrences of the sentence-transformer component naming pattern (`0_Transformer` + dense modules vs plain `Transformer`).
- **`_estimate_safetensors_kv_cache`**: unifies 2 copies (~60 lines each) of the KV cache estimation block. Uses an `async Callable` parameter to abstract the one difference between paths — how the referenced config is fetched (local creates a one-off httpx client, remote reuses the existing one). Also improves resource safety with `try/finally` on the local path's client cleanup.

Net result: ~47 fewer lines, single source of truth for all shared logic, both branches reduced to data-fetching + helper calls.