### PR TITLE
Run `uv version 0.5.1`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hf-mem"
-version = "0.5.0"
+version = "0.5.1"
 description = "A CLI to estimate inference memory requirements for Hugging Face models, written in Python."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -88,7 +88,7 @@ wheels = [
 
 [[package]]
 name = "hf-mem"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", extra = ["http2"] },


### PR DESCRIPTION
## Description
 
This PR runs `uv version 0.5.1` to update the version in `pyproject.toml` prior the release on PyPI, to incorporate a minor fix around the validation of the `--kv-cache-dtype` argument for GGUF files.

---

- [x] I have read and followed the guidelines in [`CONTRIBUTING.md`](/CONTRIBUTING.md).
- [ ] This has been discussed over an issue or discussion.