### PR TITLE
Support for hardware fit estimation

### DIFF
--- a/src/hf_mem/__init__.py
+++ b/src/hf_mem/__init__.py
@@ -1,4 +1,17 @@
 from hf_mem._version import __version__
+from hf_mem.hardware.fitness import check_fitness
+from hf_mem.hardware.types import GPU, FitnessResult, HardwareProfile, QuantizationEstimate
 from hf_mem.run import KvCache, Result, arun, run
 
-__all__ = ["__version__", "run", "arun", "Result", "KvCache"]
+__all__ = [
+    "__version__",
+    "run",
+    "arun",
+    "Result",
+    "KvCache",
+    "GPU",
+    "HardwareProfile",
+    "FitnessResult",
+    "QuantizationEstimate",
+    "check_fitness",
+]

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -105,6 +105,11 @@ def main() -> None:
         action="store_true",
         help="Include per-component dtype and parameter breakdowns in JSON output (`--json-output` only).",
     )
+    parser.add_argument(
+        "--extended",
+        action="store_true",
+        help="Show the full quantization estimates table in the hardware fitness report. Without this flag, only the minimum quantization required to fit the model is shown.",
+    )
 
     parser.add_argument(
         "--hardware",
@@ -192,4 +197,4 @@ def main() -> None:
         _print_result(result)
         if fitness is not None:
             print()
-            print_fitness_report(fitness)
+            print_fitness_report(fitness, extended=args.extended)

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -44,7 +44,7 @@ def _print_result(result: Result) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser()
 
-    parser.add_argument("--model-id", required=True, help="Model ID on the Hugging Face Hub")
+    parser.add_argument("--model-id", required=False, default=None, help="Model ID on the Hugging Face Hub")
     parser.add_argument(
         "--revision",
         default="main",
@@ -105,7 +105,43 @@ def main() -> None:
         action="store_true",
         help="Include per-component dtype and parameter breakdowns in JSON output (`--json-output` only).",
     )
+
+    parser.add_argument(
+        "--hardware",
+        type=str,
+        default=None,
+        help=(
+            "Hardware profile to check fitness against. Options: "
+            "'local' or 'auto' for GPU auto-detection, "
+            "a catalog name (e.g. 'a100-80gb', 'rtx-4090'), "
+            "a cloud instance (e.g. 'aws:p4d.24xlarge', 'azure:standard_nc24ads_a100_v4'), "
+            "a multiplier (e.g. '4x a100-80gb'), "
+            "or a bare VRAM size (e.g. '24'). "
+            "Use --list-hardware to see all built-in profiles."
+        ),
+    )
+    parser.add_argument(
+        "--hardware-file",
+        type=str,
+        default=None,
+        help='Path to a JSON file describing custom hardware. Schema: {"name": "...", "gpus": [{"name": "...", "vram_gb": N}]}.',
+    )
+    parser.add_argument(
+        "--list-hardware",
+        action="store_true",
+        help="List all built-in hardware profiles and exit.",
+    )
+
     args = parser.parse_args()
+
+    if args.list_hardware:
+        from hf_mem.hardware.print import print_catalog
+
+        print_catalog()
+        return
+
+    if args.model_id is None:
+        parser.error("--model-id is required (unless using --list-hardware)")
 
     if args.experimental:
         warnings.warn(
@@ -136,7 +172,24 @@ def main() -> None:
         )
     )
 
+    # Hardware fitness check (when --hardware or --hardware-file is provided)
+    fitness = None
+    if args.hardware or args.hardware_file:
+        from hf_mem.hardware.fitness import check_fitness
+        from hf_mem.hardware.print import print_fitness_report
+        from hf_mem.hardware.resolve import resolve_hardware
+
+        profile = resolve_hardware(hardware=args.hardware, hardware_file=args.hardware_file)
+        if profile is not None:
+            fitness = check_fitness(result, profile)
+
     if args.json_output:
-        print(json.dumps(result.to_json()))
+        output = result.to_json()
+        if fitness is not None:
+            output["fitness"] = fitness.to_json()
+        print(json.dumps(output))
     else:
         _print_result(result)
+        if fitness is not None:
+            print()
+            print_fitness_report(fitness)

--- a/src/hf_mem/hardware/__init__.py
+++ b/src/hf_mem/hardware/__init__.py
@@ -1,0 +1,15 @@
+from hf_mem.hardware.fitness import check_fitness
+from hf_mem.hardware.types import (
+    GPU,
+    FitnessResult,
+    HardwareProfile,
+    QuantizationEstimate,
+)
+
+__all__ = [
+    "GPU",
+    "HardwareProfile",
+    "QuantizationEstimate",
+    "FitnessResult",
+    "check_fitness",
+]

--- a/src/hf_mem/hardware/catalog.json
+++ b/src/hf_mem/hardware/catalog.json
@@ -1,0 +1,412 @@
+{
+  "rtx-3090": {
+    "name": "RTX 3090",
+    "source": "catalog",
+    "gpus": [{"name": "RTX 3090", "vram_gb": 24}]
+  },
+  "rtx-4090": {
+    "name": "RTX 4090",
+    "source": "catalog",
+    "gpus": [{"name": "RTX 4090", "vram_gb": 24}]
+  },
+  "rtx-5090": {
+    "name": "RTX 5090",
+    "source": "catalog",
+    "gpus": [{"name": "RTX 5090", "vram_gb": 32}]
+  },
+  "rtx-a6000": {
+    "name": "RTX A6000",
+    "source": "catalog",
+    "gpus": [{"name": "RTX A6000", "vram_gb": 48}]
+  },
+  "t4-16gb": {
+    "name": "T4 16GB",
+    "source": "catalog",
+    "gpus": [{"name": "T4", "vram_gb": 16}]
+  },
+  "v100-16gb": {
+    "name": "V100 16GB",
+    "source": "catalog",
+    "gpus": [{"name": "V100", "vram_gb": 16}]
+  },
+  "v100-32gb": {
+    "name": "V100 32GB",
+    "source": "catalog",
+    "gpus": [{"name": "V100", "vram_gb": 32}]
+  },
+  "a10-24gb": {
+    "name": "A10 24GB",
+    "source": "catalog",
+    "gpus": [{"name": "A10", "vram_gb": 24}]
+  },
+  "a10g-24gb": {
+    "name": "A10G 24GB",
+    "source": "catalog",
+    "gpus": [{"name": "A10G", "vram_gb": 24}]
+  },
+  "a30-24gb": {
+    "name": "A30 24GB",
+    "source": "catalog",
+    "gpus": [{"name": "A30", "vram_gb": 24}]
+  },
+  "a40-48gb": {
+    "name": "A40 48GB",
+    "source": "catalog",
+    "gpus": [{"name": "A40", "vram_gb": 48}]
+  },
+  "a100-40gb": {
+    "name": "A100 40GB",
+    "source": "catalog",
+    "gpus": [{"name": "A100", "vram_gb": 40}]
+  },
+  "a100-80gb": {
+    "name": "A100 80GB",
+    "source": "catalog",
+    "gpus": [{"name": "A100", "vram_gb": 80}]
+  },
+  "l4-24gb": {
+    "name": "L4 24GB",
+    "source": "catalog",
+    "gpus": [{"name": "L4", "vram_gb": 24}]
+  },
+  "l40-48gb": {
+    "name": "L40 48GB",
+    "source": "catalog",
+    "gpus": [{"name": "L40", "vram_gb": 48}]
+  },
+  "l40s-48gb": {
+    "name": "L40S 48GB",
+    "source": "catalog",
+    "gpus": [{"name": "L40S", "vram_gb": 48}]
+  },
+  "h100-80gb": {
+    "name": "H100 80GB",
+    "source": "catalog",
+    "gpus": [{"name": "H100", "vram_gb": 80}]
+  },
+  "h100-nvl-94gb": {
+    "name": "H100 NVL 94GB",
+    "source": "catalog",
+    "gpus": [{"name": "H100 NVL", "vram_gb": 94}]
+  },
+  "h200-141gb": {
+    "name": "H200 141GB",
+    "source": "catalog",
+    "gpus": [{"name": "H200", "vram_gb": 141}]
+  },
+  "b200-192gb": {
+    "name": "B200 192GB",
+    "source": "catalog",
+    "gpus": [{"name": "B200", "vram_gb": 192}]
+  },
+  "2x-a100-80gb": {
+    "name": "2x A100 80GB",
+    "source": "catalog",
+    "gpus": [
+      {"name": "A100", "vram_gb": 80},
+      {"name": "A100", "vram_gb": 80}
+    ]
+  },
+  "4x-a100-80gb": {
+    "name": "4x A100 80GB",
+    "source": "catalog",
+    "gpus": [
+      {"name": "A100", "vram_gb": 80},
+      {"name": "A100", "vram_gb": 80},
+      {"name": "A100", "vram_gb": 80},
+      {"name": "A100", "vram_gb": 80}
+    ]
+  },
+  "8x-a100-80gb": {
+    "name": "8x A100 80GB",
+    "source": "catalog",
+    "gpus": [
+      {"name": "A100", "vram_gb": 80},
+      {"name": "A100", "vram_gb": 80},
+      {"name": "A100", "vram_gb": 80},
+      {"name": "A100", "vram_gb": 80},
+      {"name": "A100", "vram_gb": 80},
+      {"name": "A100", "vram_gb": 80},
+      {"name": "A100", "vram_gb": 80},
+      {"name": "A100", "vram_gb": 80}
+    ]
+  },
+  "2x-h100-80gb": {
+    "name": "2x H100 80GB",
+    "source": "catalog",
+    "gpus": [
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80}
+    ]
+  },
+  "4x-h100-80gb": {
+    "name": "4x H100 80GB",
+    "source": "catalog",
+    "gpus": [
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80}
+    ]
+  },
+  "8x-h100-80gb": {
+    "name": "8x H100 80GB",
+    "source": "catalog",
+    "gpus": [
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80}
+    ]
+  },
+  "2x-h200-141gb": {
+    "name": "2x H200 141GB",
+    "source": "catalog",
+    "gpus": [
+      {"name": "H200", "vram_gb": 141},
+      {"name": "H200", "vram_gb": 141}
+    ]
+  },
+  "4x-h200-141gb": {
+    "name": "4x H200 141GB",
+    "source": "catalog",
+    "gpus": [
+      {"name": "H200", "vram_gb": 141},
+      {"name": "H200", "vram_gb": 141},
+      {"name": "H200", "vram_gb": 141},
+      {"name": "H200", "vram_gb": 141}
+    ]
+  },
+  "8x-h200-141gb": {
+    "name": "8x H200 141GB",
+    "source": "catalog",
+    "gpus": [
+      {"name": "H200", "vram_gb": 141},
+      {"name": "H200", "vram_gb": 141},
+      {"name": "H200", "vram_gb": 141},
+      {"name": "H200", "vram_gb": 141},
+      {"name": "H200", "vram_gb": 141},
+      {"name": "H200", "vram_gb": 141},
+      {"name": "H200", "vram_gb": 141},
+      {"name": "H200", "vram_gb": 141}
+    ]
+  },
+  "8x-b200-192gb": {
+    "name": "8x B200 192GB",
+    "source": "catalog",
+    "gpus": [
+      {"name": "B200", "vram_gb": 192},
+      {"name": "B200", "vram_gb": 192},
+      {"name": "B200", "vram_gb": 192},
+      {"name": "B200", "vram_gb": 192},
+      {"name": "B200", "vram_gb": 192},
+      {"name": "B200", "vram_gb": 192},
+      {"name": "B200", "vram_gb": 192},
+      {"name": "B200", "vram_gb": 192}
+    ]
+  },
+  "aws:p4d.24xlarge": {
+    "name": "AWS p4d.24xlarge",
+    "source": "cloud",
+    "notes": "AWS",
+    "gpus": [
+      {"name": "A100", "vram_gb": 40},
+      {"name": "A100", "vram_gb": 40},
+      {"name": "A100", "vram_gb": 40},
+      {"name": "A100", "vram_gb": 40},
+      {"name": "A100", "vram_gb": 40},
+      {"name": "A100", "vram_gb": 40},
+      {"name": "A100", "vram_gb": 40},
+      {"name": "A100", "vram_gb": 40}
+    ]
+  },
+  "aws:p4de.24xlarge": {
+    "name": "AWS p4de.24xlarge",
+    "source": "cloud",
+    "notes": "AWS",
+    "gpus": [
+      {"name": "A100", "vram_gb": 80},
+      {"name": "A100", "vram_gb": 80},
+      {"name": "A100", "vram_gb": 80},
+      {"name": "A100", "vram_gb": 80},
+      {"name": "A100", "vram_gb": 80},
+      {"name": "A100", "vram_gb": 80},
+      {"name": "A100", "vram_gb": 80},
+      {"name": "A100", "vram_gb": 80}
+    ]
+  },
+  "aws:p5.48xlarge": {
+    "name": "AWS p5.48xlarge",
+    "source": "cloud",
+    "notes": "AWS",
+    "gpus": [
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80}
+    ]
+  },
+  "aws:g5.xlarge": {
+    "name": "AWS g5.xlarge",
+    "source": "cloud",
+    "notes": "AWS",
+    "gpus": [{"name": "A10G", "vram_gb": 24}]
+  },
+  "aws:g5.48xlarge": {
+    "name": "AWS g5.48xlarge",
+    "source": "cloud",
+    "notes": "AWS",
+    "gpus": [
+      {"name": "A10G", "vram_gb": 24},
+      {"name": "A10G", "vram_gb": 24},
+      {"name": "A10G", "vram_gb": 24},
+      {"name": "A10G", "vram_gb": 24},
+      {"name": "A10G", "vram_gb": 24},
+      {"name": "A10G", "vram_gb": 24},
+      {"name": "A10G", "vram_gb": 24},
+      {"name": "A10G", "vram_gb": 24}
+    ]
+  },
+  "aws:g6.xlarge": {
+    "name": "AWS g6.xlarge",
+    "source": "cloud",
+    "notes": "AWS",
+    "gpus": [{"name": "L4", "vram_gb": 24}]
+  },
+  "aws:g6.48xlarge": {
+    "name": "AWS g6.48xlarge",
+    "source": "cloud",
+    "notes": "AWS",
+    "gpus": [
+      {"name": "L4", "vram_gb": 24},
+      {"name": "L4", "vram_gb": 24},
+      {"name": "L4", "vram_gb": 24},
+      {"name": "L4", "vram_gb": 24},
+      {"name": "L4", "vram_gb": 24},
+      {"name": "L4", "vram_gb": 24},
+      {"name": "L4", "vram_gb": 24},
+      {"name": "L4", "vram_gb": 24}
+    ]
+  },
+  "azure:standard_nc24ads_a100_v4": {
+    "name": "Azure NC24ads A100 v4",
+    "source": "cloud",
+    "notes": "Azure",
+    "gpus": [{"name": "A100", "vram_gb": 80}]
+  },
+  "azure:standard_nc48ads_a100_v4": {
+    "name": "Azure NC48ads A100 v4",
+    "source": "cloud",
+    "notes": "Azure",
+    "gpus": [
+      {"name": "A100", "vram_gb": 80},
+      {"name": "A100", "vram_gb": 80}
+    ]
+  },
+  "azure:standard_nc96ads_a100_v4": {
+    "name": "Azure NC96ads A100 v4",
+    "source": "cloud",
+    "notes": "Azure",
+    "gpus": [
+      {"name": "A100", "vram_gb": 80},
+      {"name": "A100", "vram_gb": 80},
+      {"name": "A100", "vram_gb": 80},
+      {"name": "A100", "vram_gb": 80}
+    ]
+  },
+  "azure:standard_nd96isr_h100_v5": {
+    "name": "Azure ND96isr H100 v5",
+    "source": "cloud",
+    "notes": "Azure",
+    "gpus": [
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80}
+    ]
+  },
+  "gcp:a2-highgpu-1g": {
+    "name": "GCP a2-highgpu-1g",
+    "source": "cloud",
+    "notes": "GCP",
+    "gpus": [{"name": "A100", "vram_gb": 40}]
+  },
+  "gcp:a2-highgpu-8g": {
+    "name": "GCP a2-highgpu-8g",
+    "source": "cloud",
+    "notes": "GCP",
+    "gpus": [
+      {"name": "A100", "vram_gb": 40},
+      {"name": "A100", "vram_gb": 40},
+      {"name": "A100", "vram_gb": 40},
+      {"name": "A100", "vram_gb": 40},
+      {"name": "A100", "vram_gb": 40},
+      {"name": "A100", "vram_gb": 40},
+      {"name": "A100", "vram_gb": 40},
+      {"name": "A100", "vram_gb": 40}
+    ]
+  },
+  "gcp:a2-ultragpu-8g": {
+    "name": "GCP a2-ultragpu-8g",
+    "source": "cloud",
+    "notes": "GCP",
+    "gpus": [
+      {"name": "A100", "vram_gb": 80},
+      {"name": "A100", "vram_gb": 80},
+      {"name": "A100", "vram_gb": 80},
+      {"name": "A100", "vram_gb": 80},
+      {"name": "A100", "vram_gb": 80},
+      {"name": "A100", "vram_gb": 80},
+      {"name": "A100", "vram_gb": 80},
+      {"name": "A100", "vram_gb": 80}
+    ]
+  },
+  "gcp:a3-highgpu-8g": {
+    "name": "GCP a3-highgpu-8g",
+    "source": "cloud",
+    "notes": "GCP",
+    "gpus": [
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80},
+      {"name": "H100", "vram_gb": 80}
+    ]
+  },
+  "gcp:g2-standard-4": {
+    "name": "GCP g2-standard-4",
+    "source": "cloud",
+    "notes": "GCP",
+    "gpus": [{"name": "L4", "vram_gb": 24}]
+  },
+  "gcp:g2-standard-96": {
+    "name": "GCP g2-standard-96",
+    "source": "cloud",
+    "notes": "GCP",
+    "gpus": [
+      {"name": "L4", "vram_gb": 24},
+      {"name": "L4", "vram_gb": 24},
+      {"name": "L4", "vram_gb": 24},
+      {"name": "L4", "vram_gb": 24},
+      {"name": "L4", "vram_gb": 24},
+      {"name": "L4", "vram_gb": 24},
+      {"name": "L4", "vram_gb": 24},
+      {"name": "L4", "vram_gb": 24}
+    ]
+  }
+}

--- a/src/hf_mem/hardware/catalog.py
+++ b/src/hf_mem/hardware/catalog.py
@@ -1,0 +1,54 @@
+import json
+from importlib import resources
+from typing import Any, Dict
+
+from hf_mem.hardware.types import GPU, HardwareProfile
+
+_GiB = 1024**3
+
+
+def _load_catalog() -> Dict[str, HardwareProfile]:
+    catalog_path = resources.files("hf_mem.hardware").joinpath("catalog.json")
+    raw: Dict[str, Any] = json.loads(catalog_path.read_text(encoding="utf-8"))
+
+    catalog: Dict[str, HardwareProfile] = {}
+    for key, entry in raw.items():
+        gpus = [GPU(name=g["name"], vram_bytes=int(g["vram_gb"] * _GiB)) for g in entry["gpus"]]
+        catalog[key] = HardwareProfile(
+            name=entry["name"],
+            gpus=gpus,
+            source=entry.get("source", "catalog"),
+            notes=entry.get("notes"),
+        )
+    return catalog
+
+
+CATALOG: Dict[str, HardwareProfile] = _load_catalog()
+
+
+def get_profile(key: str) -> HardwareProfile | None:
+    """Look up a hardware profile by exact key, then prefix, then substring."""
+    normalized = key.strip().lower()
+
+    # Exact match
+    if normalized in CATALOG:
+        return CATALOG[normalized]
+
+    # Prefix match
+    for catalog_key, profile in CATALOG.items():
+        if catalog_key.startswith(normalized):
+            return profile
+
+    # Segment match: input must match a full segment (split by - or space)
+    # e.g. "h100" matches "h100-80gb" but "8gb" does NOT match "a40-48gb"
+    for catalog_key, profile in CATALOG.items():
+        key_segments = catalog_key.split("-")
+        name_segments = profile.name.lower().split()
+        if normalized in key_segments or normalized in name_segments:
+            return profile
+
+    return None
+
+
+def list_profiles() -> Dict[str, HardwareProfile]:
+    return CATALOG

--- a/src/hf_mem/hardware/custom.py
+++ b/src/hf_mem/hardware/custom.py
@@ -1,0 +1,39 @@
+import json
+from typing import Any, Dict
+
+from hf_mem.hardware.types import GPU, HardwareProfile
+
+_GiB = 1024**3
+
+
+def load_custom_profile(path: str) -> HardwareProfile:
+    """Load a hardware profile from a JSON file.
+
+    Expected schema:
+        {
+            "name": "Our Slurm node",
+            "gpus": [
+                {"name": "A100-SXM4", "vram_gb": 80},
+                {"name": "A100-SXM4", "vram_gb": 80}
+            ],
+            "system_ram_gb": 512   // optional
+        }
+    """
+    with open(path, "r") as f:
+        data: Dict[str, Any] = json.load(f)
+
+    if "gpus" not in data or not isinstance(data["gpus"], list) or len(data["gpus"]) == 0:
+        raise RuntimeError(f"Hardware config at '{path}' must have a non-empty 'gpus' list.")
+
+    gpus = []
+    for i, g in enumerate(data["gpus"]):
+        if "name" not in g or "vram_gb" not in g:
+            raise RuntimeError(f"GPU entry {i} in '{path}' must have 'name' and 'vram_gb' fields.")
+        gpus.append(GPU(name=g["name"], vram_bytes=int(g["vram_gb"] * _GiB)))
+
+    return HardwareProfile(
+        name=data.get("name", path),
+        gpus=gpus,
+        source="custom",
+        system_ram_bytes=int(data["system_ram_gb"] * _GiB) if "system_ram_gb" in data else None,
+    )

--- a/src/hf_mem/hardware/detect.py
+++ b/src/hf_mem/hardware/detect.py
@@ -1,0 +1,51 @@
+import subprocess
+
+from hf_mem.hardware.types import GPU, HardwareProfile
+
+
+def detect_local_gpus() -> HardwareProfile:
+    """Detect NVIDIA GPUs via nvidia-smi. Raises RuntimeError on failure."""
+    try:
+        result = subprocess.run(
+            ["nvidia-smi", "--query-gpu=name,memory.total", "--format=csv,noheader,nounits"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except FileNotFoundError:
+        raise RuntimeError(
+            "nvidia-smi not found — cannot auto-detect GPUs. "
+            "Specify hardware manually with `--hardware <profile>`. "
+            "Run `hf-mem --list-hardware` to see available profiles."
+        )
+    except subprocess.TimeoutExpired:
+        raise RuntimeError("nvidia-smi timed out after 10s. Is the NVIDIA driver responsive?")
+
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        raise RuntimeError(
+            f"nvidia-smi failed (exit code {result.returncode}): {stderr}. "
+            "Specify hardware manually with `--hardware <profile>`."
+        )
+
+    gpus = []
+    for line in result.stdout.strip().splitlines():
+        parts = line.rsplit(",", 1)
+        if len(parts) != 2:
+            continue
+        name = parts[0].strip()
+        try:
+            mem_mib = int(parts[1].strip())
+        except ValueError:
+            continue
+        gpus.append(GPU(name=name, vram_bytes=mem_mib * 1024 * 1024))
+
+    if not gpus:
+        raise RuntimeError(
+            "nvidia-smi returned no GPUs. "
+            "Specify hardware manually with `--hardware <profile>`. "
+            "Run `hf-mem --list-hardware` to see available profiles."
+        )
+
+    profile_name = f"{len(gpus)}x {gpus[0].name}" if len(gpus) > 1 else gpus[0].name
+    return HardwareProfile(name=profile_name, gpus=gpus, source="local")

--- a/src/hf_mem/hardware/fitness.py
+++ b/src/hf_mem/hardware/fitness.py
@@ -1,0 +1,103 @@
+import math
+from typing import List
+
+from hf_mem.gguf.types import GGUFDtype, GGUFDtypeBitsPerWeight
+from hf_mem.hardware.types import FitnessResult, HardwareProfile, QuantizationEstimate
+from hf_mem.run import Result
+
+_QUANT_LEVELS: List[tuple[str, float]] = [
+    ("F16", GGUFDtypeBitsPerWeight[GGUFDtype.F16]),
+    ("BF16", GGUFDtypeBitsPerWeight[GGUFDtype.BF16]),
+    ("Q8_K", GGUFDtypeBitsPerWeight[GGUFDtype.Q8_K]),
+    ("Q6_K", GGUFDtypeBitsPerWeight[GGUFDtype.Q6_K]),
+    ("Q5_K", GGUFDtypeBitsPerWeight[GGUFDtype.Q5_K]),
+    ("Q4_K", GGUFDtypeBitsPerWeight[GGUFDtype.Q4_K]),
+    ("Q3_K", GGUFDtypeBitsPerWeight[GGUFDtype.Q3_K]),
+    ("Q2_K", GGUFDtypeBitsPerWeight[GGUFDtype.Q2_K]),
+    ("IQ4_XS", GGUFDtypeBitsPerWeight[GGUFDtype.IQ4_XS]),
+    ("IQ3_S", GGUFDtypeBitsPerWeight[GGUFDtype.IQ3_S]),
+    ("IQ2_XS", GGUFDtypeBitsPerWeight[GGUFDtype.IQ2_XS]),
+]
+
+
+def check_fitness(result: Result, profile: HardwareProfile) -> FitnessResult:
+    """Check whether a model estimation fits on the given hardware profile."""
+    if result.total_memory is None:
+        raise RuntimeError(
+            "Fitness check requires a single-file memory estimate (`total_memory` must not be None). "
+            "Use `--gguf-file` to select a specific GGUF file."
+        )
+
+    total_vram = profile.total_vram_bytes
+    total_needed = result.total_memory
+    model_memory = result.memory if isinstance(result.memory, int) else 0
+
+    fits = total_needed <= total_vram
+    headroom = total_vram - total_needed
+    headroom_pct = headroom / total_vram if total_vram > 0 else 0.0
+
+    # How many GPUs of this type would be needed?
+    per_gpu_vram = min(g.vram_bytes for g in profile.gpus) if profile.gpus else 0
+    gpu_count_needed = math.ceil(total_needed / per_gpu_vram) if per_gpu_vram > 0 else 0
+
+    param_count: int | None = result.param_count if isinstance(result.param_count, int) else None
+
+    kv_cache_bytes = 0
+    if isinstance(result.kv_cache, int):
+        kv_cache_bytes = result.kv_cache
+
+    quant_options: List[QuantizationEstimate] = []
+    if param_count is not None:
+        for name, bits in _QUANT_LEVELS:
+            est_bytes = int(param_count * bits / 8.0)
+            est_total = est_bytes + kv_cache_bytes
+            q_fits = est_total <= total_vram
+            q_gpus = math.ceil(est_total / per_gpu_vram) if per_gpu_vram > 0 else 0
+            quant_options.append(
+                QuantizationEstimate(
+                    name=name,
+                    bits_per_weight=bits,
+                    estimated_bytes=est_bytes,
+                    estimated_total_bytes=est_total,
+                    fits=q_fits,
+                    gpu_count_needed=q_gpus,
+                )
+            )
+
+    notes: List[str] = []
+    if gpu_count_needed > len(profile.gpus):
+        if quant_options:
+            # First quant that fits (highest quality, list is sorted bits desc)
+            first_fit = next((q for q in quant_options if q.gpu_count_needed <= len(profile.gpus)), None)
+            if first_fit is not None:
+                notes.append(
+                    f"Does not fit at full precision ({gpu_count_needed} GPUs). {first_fit.name} or below fits."
+                )
+            else:
+                # Even most aggressive quant doesn't fit
+                most_aggressive = min(quant_options, key=lambda q: q.estimated_total_bytes)
+                notes.append(
+                    f"Needs {gpu_count_needed} GPUs at full precision, "
+                    f"{most_aggressive.gpu_count_needed} at {most_aggressive.name}. "
+                    f"Profile has {len(profile.gpus)}."
+                )
+        else:
+            notes.append(f"Needs {gpu_count_needed} GPUs but profile has {len(profile.gpus)}.")
+    elif gpu_count_needed > 1:
+        notes.append(f"Requires tensor parallelism across {gpu_count_needed} GPUs.")
+
+    if fits and 0 <= headroom_pct < 0.10:
+        notes.append("Tight fit (<10% headroom). May OOM under load.")
+
+    return FitnessResult(
+        profile=profile,
+        model_memory=model_memory,
+        total_memory=total_needed,
+        fits=fits,
+        headroom_bytes=headroom,
+        headroom_pct=headroom_pct,
+        gpu_count_needed=gpu_count_needed,
+        param_count=param_count,
+        quantization_options=quant_options,
+        notes=notes,
+    )

--- a/src/hf_mem/hardware/print.py
+++ b/src/hf_mem/hardware/print.py
@@ -16,7 +16,7 @@ from hf_mem.hardware.catalog import list_profiles
 from hf_mem.hardware.types import FitnessResult
 
 
-def print_fitness_report(fitness: FitnessResult) -> None:
+def print_fitness_report(fitness: FitnessResult, *, extended: bool = False) -> None:
     profile = fitness.profile
     total_vram_gib = _bytes_to_gib(profile.total_vram_bytes)
     gpu_count = len(profile.gpus)
@@ -88,30 +88,55 @@ def print_fitness_report(fitness: FitnessResult) -> None:
 
     # Quantization estimates
     if fitness.quantization_options:
-        _print_divider(data_col_width + 1, side="top-continue")
-        _print_centered("QUANTIZATION ESTIMATES", current_len)
-        _print_divider(data_col_width + 1, side="top")
+        if extended:
+            _print_divider(data_col_width + 1, side="top-continue")
+            _print_centered("QUANTIZATION ESTIMATES", current_len)
+            _print_divider(data_col_width + 1, side="top")
 
-        # Find max lengths for alignment within the quant section
-        max_qname_len = max(len(q.name) for q in fitness.quantization_options)
-        bpw_labels = [f"{q.bits_per_weight}b" for q in fitness.quantization_options]
-        max_bpw_len = max(len(l) for l in bpw_labels)
+            # Find max lengths for alignment within the quant section
+            max_qname_len = max(len(q.name) for q in fitness.quantization_options)
+            bpw_labels = [f"{q.bits_per_weight}b" for q in fitness.quantization_options]
+            max_bpw_len = max(len(l) for l in bpw_labels)
 
-        for i, q in enumerate(fitness.quantization_options):
-            est_gib = _bytes_to_gib(q.estimated_total_bytes)
-            label = "FITS" if q.fits else "NO"
-            if q.gpu_count_needed > 1 and q.fits:
-                label = f"FITS ({q.gpu_count_needed} GPUs)"
+            for i, q in enumerate(fitness.quantization_options):
+                est_gib = _bytes_to_gib(q.estimated_total_bytes)
+                label = "FITS" if q.fits else "NO"
+                if q.gpu_count_needed > 1 and q.fits:
+                    label = f"FITS ({q.gpu_count_needed} GPUs)"
 
-            padded_name = q.name + " " * (max_qname_len - len(q.name))
-            _print_row(padded_name, f"{est_gib:.2f} GiB  {label}", data_col_width)
+                padded_name = q.name + " " * (max_qname_len - len(q.name))
+                _print_row(padded_name, f"{est_gib:.2f} GiB  {label}", data_col_width)
 
-            bar = _make_bar(q.estimated_total_bytes, profile.total_vram_bytes, data_col_width)
-            bpw_label = bpw_labels[i] + " " * (max_bpw_len - len(bpw_labels[i]))
-            _print_row(bpw_label, bar, data_col_width)
+                bar = _make_bar(q.estimated_total_bytes, profile.total_vram_bytes, data_col_width)
+                bpw_label = bpw_labels[i] + " " * (max_bpw_len - len(bpw_labels[i]))
+                _print_row(bpw_label, bar, data_col_width)
 
-            if i < len(fitness.quantization_options) - 1:
+                if i < len(fitness.quantization_options) - 1:
+                    _print_divider(data_col_width + 1)
+        else:
+            # Compact mode: show only the minimum quantization required to fit
+            # (first entry that fits = highest quality / least aggressive quantization)
+            min_quant = next((q for q in fitness.quantization_options if q.fits), None)
+            if min_quant is not None:
                 _print_divider(data_col_width + 1)
+                est_gib = _bytes_to_gib(min_quant.estimated_total_bytes)
+                gpu_note = f" ({min_quant.gpu_count_needed} GPUs)" if min_quant.gpu_count_needed > 1 else ""
+                _print_row(
+                    "MIN QUANT",
+                    f"{min_quant.name} ({min_quant.bits_per_weight}b) — {est_gib:.2f} GiB{gpu_note}",
+                    data_col_width,
+                )
+                bar = _make_bar(min_quant.estimated_total_bytes, profile.total_vram_bytes, data_col_width)
+                _print_row(f"{min_quant.bits_per_weight}b", bar, data_col_width)
+            else:
+                _print_divider(data_col_width + 1)
+                most_aggressive = min(fitness.quantization_options, key=lambda q: q.estimated_total_bytes)
+                est_gib = _bytes_to_gib(most_aggressive.estimated_total_bytes)
+                _print_row(
+                    "MIN QUANT",
+                    f"Does not fit even at {most_aggressive.name} ({est_gib:.2f} GiB)",
+                    data_col_width,
+                )
 
     # Notes
     if fitness.notes:

--- a/src/hf_mem/hardware/print.py
+++ b/src/hf_mem/hardware/print.py
@@ -1,0 +1,158 @@
+from hf_mem._print import (
+    BORDERS_AND_PADDING,
+    MAX_DATA_LEN,
+    MAX_NAME_LEN,
+    _bytes_to_gib,
+    _make_bar,
+    _print_centered,
+    _print_divider,
+    _print_full_divider,
+    _print_header,
+    _print_row,
+    _print_with_color,
+)
+from hf_mem._version import __version__
+from hf_mem.hardware.catalog import list_profiles
+from hf_mem.hardware.types import FitnessResult
+
+
+def print_fitness_report(fitness: FitnessResult) -> None:
+    profile = fitness.profile
+    total_vram_gib = _bytes_to_gib(profile.total_vram_bytes)
+    gpu_count = len(profile.gpus)
+
+    # Build centered header rows
+    centered_rows = [
+        "HARDWARE FITNESS CHECK",
+        profile.name,
+    ]
+    if gpu_count > 1:
+        per_gpu_gib = _bytes_to_gib(profile.gpus[0].vram_bytes)
+        centered_rows.append(f"{gpu_count}x GPUs, {per_gpu_gib:.0f} GiB each, {total_vram_gib:.0f} GiB total")
+    else:
+        centered_rows.append(f"{total_vram_gib:.0f} GiB VRAM")
+
+    # Build data rows to determine data column width
+    model_gib = _bytes_to_gib(fitness.model_memory)
+    total_gib = _bytes_to_gib(fitness.total_memory)
+    headroom_gib = _bytes_to_gib(abs(fitness.headroom_bytes))
+    headroom_sign = "" if fitness.headroom_bytes >= 0 else "-"
+
+    status_text = "FITS" if fitness.fits else f"DOES NOT FIT (needs {total_gib:.2f} GiB)"
+
+    data_rows = [
+        status_text,
+        f"{model_gib:.2f} GiB (weights)",
+        f"{total_gib:.2f} GiB",
+        f"{headroom_sign}{headroom_gib:.2f} GiB ({fitness.headroom_pct * 100:.1f}%)",
+    ]
+    for q in fitness.quantization_options:
+        est_gib = _bytes_to_gib(q.estimated_total_bytes)
+        label = "FITS" if q.fits else "NO"
+        if q.gpu_count_needed > 1 and q.fits:
+            label = f"FITS ({q.gpu_count_needed} GPUs)"
+        data_rows.append(f"{est_gib:.2f} GiB  {label}")
+
+    # Compute widths (same pattern as safetensors/print.py)
+    max_centered_len = max(len(r) for r in centered_rows)
+    max_data_len = max(len(r) for r in data_rows)
+    min_width_for_data = MAX_NAME_LEN + max_data_len + 5
+    current_len = max(max_centered_len, min_width_for_data, MAX_DATA_LEN)
+    data_col_width = current_len + 2 * BORDERS_AND_PADDING - MAX_NAME_LEN - 5
+
+    # Header
+    _print_header(current_len, badge=f"hf-mem {__version__}")
+    for row in centered_rows:
+        _print_centered(row, current_len)
+
+    # Status section
+    _print_divider(data_col_width + 1, side="top")
+    _print_row("STATUS", status_text, data_col_width)
+    pct = min(fitness.total_memory / profile.total_vram_bytes * 100, 999) if profile.total_vram_bytes > 0 else 0
+    bar_width = data_col_width - len(f" {pct:.0f}%")
+    bar = _make_bar(fitness.total_memory, profile.total_vram_bytes, bar_width)
+    _print_row("UTILIZATION", f"{bar} {pct:.0f}%", data_col_width)
+
+    _print_divider(data_col_width + 1)
+    _print_row("MODEL", f"{model_gib:.2f} GiB (weights)", data_col_width)
+    if fitness.total_memory != fitness.model_memory:
+        kv_gib = _bytes_to_gib(fitness.total_memory - fitness.model_memory)
+        _print_row("KV CACHE", f"{kv_gib:.2f} GiB", data_col_width)
+    _print_row("TOTAL", f"{total_gib:.2f} GiB", data_col_width)
+    _print_row(
+        "HEADROOM", f"{headroom_sign}{headroom_gib:.2f} GiB ({fitness.headroom_pct * 100:.1f}%)", data_col_width
+    )
+
+    if fitness.gpu_count_needed > 1:
+        _print_row("MIN GPUs", f"{fitness.gpu_count_needed}x {profile.gpus[0].name}", data_col_width)
+
+    # Quantization estimates
+    if fitness.quantization_options:
+        _print_divider(data_col_width + 1, side="top-continue")
+        _print_centered("QUANTIZATION ESTIMATES", current_len)
+        _print_divider(data_col_width + 1, side="top")
+
+        # Find max lengths for alignment within the quant section
+        max_qname_len = max(len(q.name) for q in fitness.quantization_options)
+        bpw_labels = [f"{q.bits_per_weight}b" for q in fitness.quantization_options]
+        max_bpw_len = max(len(l) for l in bpw_labels)
+
+        for i, q in enumerate(fitness.quantization_options):
+            est_gib = _bytes_to_gib(q.estimated_total_bytes)
+            label = "FITS" if q.fits else "NO"
+            if q.gpu_count_needed > 1 and q.fits:
+                label = f"FITS ({q.gpu_count_needed} GPUs)"
+
+            padded_name = q.name + " " * (max_qname_len - len(q.name))
+            _print_row(padded_name, f"{est_gib:.2f} GiB  {label}", data_col_width)
+
+            bar = _make_bar(q.estimated_total_bytes, profile.total_vram_bytes, data_col_width)
+            bpw_label = bpw_labels[i] + " " * (max_bpw_len - len(bpw_labels[i]))
+            _print_row(bpw_label, bar, data_col_width)
+
+            if i < len(fitness.quantization_options) - 1:
+                _print_divider(data_col_width + 1)
+
+    # Notes
+    if fitness.notes:
+        _print_full_divider(current_len, side="top-continue")
+        for note in fitness.notes:
+            _print_centered(note, current_len)
+
+    # Bottom border
+    if fitness.notes:
+        _print_full_divider(current_len, side="bottom")
+    else:
+        _print_divider(data_col_width + 1, side="bottom")
+
+
+def print_catalog() -> None:
+    """Print the built-in hardware catalog as a table."""
+    profiles = list_profiles()
+
+    rows = []
+    for key, p in profiles.items():
+        gpu_count = len(p.gpus)
+        total_gib = _bytes_to_gib(p.total_vram_bytes)
+        gpu_desc = f"{gpu_count}x {p.gpus[0].name}" if gpu_count > 1 else p.gpus[0].name
+        rows.append((key, gpu_desc, f"{total_gib:.0f} GiB", p.source))
+
+    key_width = max(len(r[0]) for r in rows)
+    gpu_width = max(len(r[1]) for r in rows)
+    vram_width = max(len(r[2]) for r in rows)
+    source_width = max(len(r[3]) for r in rows)
+
+    header_key = "PROFILE".ljust(key_width)
+    header_gpu = "GPU".ljust(gpu_width)
+    header_vram = "VRAM".ljust(vram_width)
+    header_source = "SOURCE".ljust(source_width)
+
+    _print_with_color(f"  {header_key}  {header_gpu}  {header_vram}  {header_source}")
+    _print_with_color(f"  {'─' * key_width}  {'─' * gpu_width}  {'─' * vram_width}  {'─' * source_width}")
+
+    for key, gpu_desc, vram, source in rows:
+        k = key.ljust(key_width)
+        g = gpu_desc.ljust(gpu_width)
+        v = vram.ljust(vram_width)
+        s = source.ljust(source_width)
+        _print_with_color(f"  {k}  {g}  {v}  {s}")

--- a/src/hf_mem/hardware/resolve.py
+++ b/src/hf_mem/hardware/resolve.py
@@ -1,0 +1,81 @@
+import re
+
+from hf_mem.hardware.catalog import get_profile
+from hf_mem.hardware.custom import load_custom_profile
+from hf_mem.hardware.detect import detect_local_gpus
+from hf_mem.hardware.types import GPU, HardwareProfile
+
+_GiB = 1024**3
+
+# Matches "4x a100-80gb" or "4xa100-80gb"
+_MULTI_GPU_RE = re.compile(r"^(\d+)\s*x\s*(.+)$", re.IGNORECASE)
+
+# Matches bare VRAM like "24gb", "24gib", "24g", or just "24"
+_VRAM_RE = re.compile(r"^(\d+)\s*(gib|gb|g)?$", re.IGNORECASE)
+
+
+def resolve_hardware(
+    hardware: str | None = None,
+    hardware_file: str | None = None,
+) -> HardwareProfile | None:
+    """Resolve a --hardware or --hardware-file argument into a HardwareProfile."""
+    if hardware_file is not None:
+        return load_custom_profile(hardware_file)
+
+    if hardware is None:
+        return None
+
+    value = hardware.strip()
+    lower = value.lower()
+
+    # 1. "local" or "auto" -> detect GPUs
+    if lower in ("local", "auto"):
+        return detect_local_gpus()
+
+    # 2. "4x a100-80gb" -> multiply a single-GPU catalog entry
+    if m := _MULTI_GPU_RE.match(lower):
+        count = int(m.group(1))
+        base_key = m.group(2).strip()
+        base = get_profile(base_key)
+        if base is None:
+            raise RuntimeError(
+                f"Unknown hardware profile: '{base_key}'. "
+                "Run `hf-mem --list-hardware` to see available profiles."
+            )
+        if len(base.gpus) != 1:
+            raise RuntimeError(
+                f"Multiplier syntax only works with single-GPU profiles, "
+                f"but '{base_key}' has {len(base.gpus)} GPUs."
+            )
+        return HardwareProfile(
+            name=f"{count}x {base.name}",
+            gpus=base.gpus * count,
+            source=base.source,
+            notes=base.notes,
+        )
+
+    # 3. Direct catalog lookup (exact, prefix, substring)
+    profile = get_profile(lower)
+    if profile is not None:
+        return profile
+
+    # 4. Bare VRAM: "24", "24gb", "24gib", "24g"
+    if m := _VRAM_RE.match(lower):
+        vram_val = int(m.group(1))
+        unit = (m.group(2) or "gib").lower()
+        if unit == "gb":
+            vram_bytes = vram_val * 1000**3
+        else:  # gib, g, or bare number
+            vram_bytes = vram_val * _GiB
+        return HardwareProfile(
+            name=f"Custom GPU ({vram_val} {'GB' if unit == 'gb' else 'GiB'})",
+            gpus=[GPU(name="Custom", vram_bytes=vram_bytes)],
+            source="custom",
+        )
+
+    raise RuntimeError(
+        f"Unknown hardware profile: '{hardware}'. "
+        "Use '--hardware local' for auto-detection, a catalog name like 'a100-80gb', "
+        "a cloud instance like 'aws:p4d.24xlarge', or '--hardware-file config.json'. "
+        "Run `hf-mem --list-hardware` to see all profiles."
+    )

--- a/src/hf_mem/hardware/types.py
+++ b/src/hf_mem/hardware/types.py
@@ -1,0 +1,84 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+@dataclass
+class GPU:
+    name: str
+    vram_bytes: int
+
+
+@dataclass
+class HardwareProfile:
+    name: str
+    gpus: List[GPU]
+    source: str
+    total_vram_bytes: int = 0
+    system_ram_bytes: int | None = None
+    notes: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.total_vram_bytes == 0:
+            self.total_vram_bytes = sum(g.vram_bytes for g in self.gpus)
+
+    def to_json(self) -> Dict[str, Any]:
+        out: Dict[str, Any] = {
+            "name": self.name,
+            "source": self.source,
+            "total_vram_bytes": self.total_vram_bytes,
+            "gpu_count": len(self.gpus),
+            "gpus": [{"name": g.name, "vram_bytes": g.vram_bytes} for g in self.gpus],
+        }
+        if self.system_ram_bytes is not None:
+            out["system_ram_bytes"] = self.system_ram_bytes
+        if self.notes is not None:
+            out["notes"] = self.notes
+        return out
+
+
+@dataclass
+class QuantizationEstimate:
+    name: str
+    bits_per_weight: float
+    estimated_bytes: int
+    estimated_total_bytes: int
+    fits: bool
+    gpu_count_needed: int
+
+
+@dataclass
+class FitnessResult:
+    profile: HardwareProfile
+    model_memory: int
+    total_memory: int
+    fits: bool
+    headroom_bytes: int
+    headroom_pct: float
+    gpu_count_needed: int
+    param_count: int | None
+    quantization_options: List[QuantizationEstimate] = field(default_factory=list)
+    notes: List[str] = field(default_factory=list)
+
+    def to_json(self) -> Dict[str, Any]:
+        return {
+            "profile": self.profile.to_json(),
+            "model_memory": self.model_memory,
+            "total_memory": self.total_memory,
+            "fits": self.fits,
+            "headroom_bytes": self.headroom_bytes,
+            "headroom_pct": round(self.headroom_pct, 4),
+            "gpu_count_needed": self.gpu_count_needed,
+            "param_count": self.param_count,
+            "quantization_options": [
+                {
+                    "name": q.name,
+                    "bits_per_weight": q.bits_per_weight,
+                    "estimated_bytes": q.estimated_bytes,
+                    "estimated_total_bytes": q.estimated_total_bytes,
+                    "fits": q.fits,
+                    "gpu_count_needed": q.gpu_count_needed,
+                }
+                for q in self.quantization_options
+            ],
+            "notes": self.notes,
+        }

--- a/src/hf_mem/run.py
+++ b/src/hf_mem/run.py
@@ -39,6 +39,8 @@ class Result:
     kv_cache: Union[int, Dict[str, int], None]
     # `total_memory` is memory + kv_cache for single-file results; None for multi-GGUF
     total_memory: int | None
+    # `param_count` mirrors the shape of `memory` — scalar for single-file, dict for multi-GGUF
+    param_count: Union[int, Dict[str, int], None] = None
 
     # NOTE: When True, to_json() enriches `memory` and `kv_cache` with per-component /
     # per-dtype breakdowns rather than bare byte counts
@@ -57,6 +59,7 @@ class Result:
             out["memory"] = self.memory
             out["kv_cache"] = self.kv_cache
             out["total_memory"] = self.total_memory
+            out["param_count"] = self.param_count
             return out
 
         if self.safetensors is not None:
@@ -147,6 +150,7 @@ class Result:
                 )
 
         out["total_memory"] = self.total_memory
+        out["param_count"] = self.param_count
         return out
 
 
@@ -292,6 +296,7 @@ async def arun(
                 memory=gguf_meta.bytes_count,
                 kv_cache=kv_bytes,
                 total_memory=gguf_meta.bytes_count + (kv_bytes or 0),
+                param_count=gguf_meta.param_count,
                 details=details,
                 gguf_files=gguf_files_dict,
             )
@@ -316,6 +321,7 @@ async def arun(
                 memory=memory_dict,
                 kv_cache=kv_dict,
                 total_memory=None,
+                param_count={fn: m.param_count for fn, m in gguf_files_dict.items()},
                 details=details,
                 gguf_files=gguf_files_dict,
             )
@@ -508,6 +514,7 @@ async def arun(
         memory=metadata.bytes_count,
         kv_cache=kv_bytes,
         total_memory=metadata.bytes_count + (kv_bytes or 0),
+        param_count=metadata.param_count,
         details=details,
         safetensors=metadata,
         kv_cache_metadata=kv_cache_cls,


### PR DESCRIPTION
This is my take on #29. 

The idea is to have a fitness function that given the `model-id` (optionally including kv-cache) and a hardware configuration will tell the user if the model will fit and if so using which quantization. 

The user can specify which hardware configuration to use by specifying the flag `--hardware` which can be either `auto` for auto-detection (only if `nvidia-smi` is installed, current limitation) or a key in the `catalog.json` file (which is a very simple solution which can be expanded/improved).

---

- [x] I have read and followed the guidelines in [`CONTRIBUTING.md`](/CONTRIBUTING.md).
- [x] This has been discussed over an issue or discussion.
