### PR TITLE
Exclude `mmproj-` from GGUF estimation

### DIFF
--- a/src/hf_mem/gguf/metadata.py
+++ b/src/hf_mem/gguf/metadata.py
@@ -133,7 +133,6 @@ def parse_gguf_metadata(
             for key in kv_metadata
             if key.endswith(ending)
         }
-
         if max_model_len is not None:
             kv_cache_dict["context_length"] = max_model_len
 

--- a/src/hf_mem/run.py
+++ b/src/hf_mem/run.py
@@ -216,7 +216,10 @@ async def arun(
     files = await get_json_file(client=client, url=url, headers=headers)
     file_paths = [f["path"] for f in files if f.get("path") and f.get("type") == "file"]
 
-    gguf_paths = [f for f in file_paths if str(f).endswith(".gguf")]
+    # NOTE: Exclude the `mmproj-*` files as those are the multimodal projection and not the language model
+    # weights per se, so excluding those from the estimation (especifically when `--experimental`)
+    # See https://github.com/alvarobartt/hf-mem/issues/47
+    gguf_paths = [f for f in file_paths if str(f).endswith(".gguf") and not f.__contains__("mmproj-")]
     has_safetensors = any(
         f in ["model.safetensors", "model.safetensors.index.json", "model_index.json"] for f in file_paths
     )


### PR DESCRIPTION
## Description

This PR excludes the `mmproj-` i.e., the multimodal projection files, which are included in the GGUF repositories for VLMs, as those are not used for the current estimation. Ideally we should include those as those require some memory to load despite smaller than the language-model per se, but shouldn't be included along with the rest of the files (+ the KV cache estimations won't apply).

> [!WARN]
> This PR is just a temporary patch, but the `mmproj-` files should indeed be handled and included within the per-file estimation, but it's rather tricky given that the `mmproj-` also comes on different dtypes, so we'll just skip it and include a proper fix later on.

Closes #47 

---

- [x] I have read and followed the guidelines in [`CONTRIBUTING.md`](/CONTRIBUTING.md).
- [x] This has been discussed over an issue or discussion.
