### PR TITLE
improve hf-mem skill structure + eval score

### DIFF
--- a/skills/hf-mem/SKILL.md
+++ b/skills/hf-mem/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hf-mem
-description: CLI to estimate the required memory to load either Safetensors or GGUF model weights for inference from the Hugging Face Hub
+description: CLI to estimate the required VRAM / GPU memory to load Safetensors or GGUF model weights for inference from the Hugging Face Hub. Use when the user asks about memory requirements, RAM usage, model size, or whether a model fits on a given GPU.
 license: mit
 ---
 


### PR DESCRIPTION
hey @alvarobartt, thanks for building hf-mem. really like having a clean CLI for estimating inference memory requirements. Kudos on approaching `900` stars! I've just starred it.

ran your hf-mem skill through agent evals and spotted a few quick wins that took it from `~93%` to `~100%` performance:

- expanded description with trigger terms like _VRAM estimation, model memory, quantization, inference requirements_ so agents reliably match user requests

- tightened workflow steps + added concrete verification checkpoints

these were easy changes to bring the skill in line with what **performs well against Anthropic's best practices**. honest disclosure, I work at tessl.io where we build tooling around this. not a pitch, just fixes that were straightforward to make!

you've got `1` skill, if you want to do it yourself, spin up Claude Code and run `tessl skill review`. alternatively, let me know if you'd like an automatic review in your repo via GitHub Actions. it doesn't require signup, and this means you and your contributors get an instant quality signal before you have to review yourself.