### PR TITLE
Fix missing dtype/quantization_config

### DIFF
--- a/src/hf_mem/run.py
+++ b/src/hf_mem/run.py
@@ -474,6 +474,10 @@ async def arun(
                     referenced_config.update(text_config)
                     text_config = referenced_config
 
+                for key in ("dtype", "torch_dtype", "quantization_config"):
+                    if key in config and key not in text_config:
+                        text_config[key] = config[key]
+
                 config = text_config
 
             if max_model_len is None:


### PR DESCRIPTION
## Description

Some models (e.g. https://huggingface.co/mistralai/Mistral-Small-4-119B-2603) have the top-level config replaced with `text_config` for specific fields, but fields like `dtype`, `torch_dtype`, and `quantization_config` *may* live at the top-level config, not inside `text_config`, so `resolve_kv_cache_dtype` would fail with a `RuntimeError` claiming the dtype could not be resolved.

This is not the case for the mayority of models, because they also have the `d-type`-like fields on the text_config, but some other models do not. This fix copies `dtype`, `torch_dtype`, and `quantization_config` from the top-level config into `text_config` (if not present)

Before:

`hf-mem --model-id mistralai/Mistral-Small-4-119B-2603 --experimental` fails with RuntimeError

Now: `hf-mem --model-id mistralai/Mistral-Small-4-119B-2603 --experimental` correctly resolves `F8_E4M3` from `quantization_config`

---

- [x] I have read and followed the guidelines in [`CONTRIBUTING.md`](/CONTRIBUTING.md).
- [ ] This has been discussed over an issue or discussion.
