### PR TITLE
Add support for F8_E8M0 dtype

### DIFF
--- a/src/hf_mem/safetensors/types.py
+++ b/src/hf_mem/safetensors/types.py
@@ -26,7 +26,7 @@ def get_safetensors_dtype_bytes(dtype: SafetensorsDtypes | str) -> int:
             return 4
         case "F16" | "BF16" | "I16" | "U16":
             return 2
-        case "F8_E5M2" | "F8_E4M3" | "I8" | "U8":
+        case "F8_E5M2" | "F8_E4M3" | "F8_E8M0" | "I8" | "U8":
             return 1
         case _:
             raise RuntimeError(f"DTYPE={dtype} NOT HANDLED")

--- a/src/hf_mem/safetensors/types.py
+++ b/src/hf_mem/safetensors/types.py
@@ -11,6 +11,7 @@ SafetensorsDtypes = Literal[
     "BF16",
     "I16",
     "U16",
+    "F8_E8M0",
     "F8_E5M2",  # NOTE: Only CUDA +11.8
     "F8_E4M3",  # NOTE: CUDA +11.8 and AMD ROCm
     "I8",


### PR DESCRIPTION
Add support for F8_E8M0 dtype

Fixes crash when running:
hf-mem --model-id deepseek-ai/DeepSeek-V4-Pro

This is an FP8 format → 1 byte per element.

Closes #56 
---

- [x] I have read and followed the guidelines in [`CONTRIBUTING.md`](/CONTRIBUTING.md).
- [x] This has been discussed over an issue or discussion.
