### PR TITLE
Release `version` v0.5.3, update image URLs in `README.md` and explain `hf extensions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://github.com/user-attachments/assets/509a8244-8a91-4051-b337-41b7b2fe0e2f" />
+<img src="https://huggingface.co/datasets/alvarobartt/hf-mem/resolve/main/hf-mem.png" />
 
 ---
 
@@ -21,7 +21,7 @@ Read more information about `hf-mem` in [this short-form post](https://alvarobar
 uvx hf-mem --model-id MiniMaxAI/MiniMax-M2
 ```
 
-<img src="https://github.com/user-attachments/assets/545be630-4485-41ac-ba8d-2aedbbed8835" />
+<img src="https://huggingface.co/datasets/alvarobartt/hf-mem/resolve/main/transformers.png" />
 
 #### Diffusers
 
@@ -29,7 +29,7 @@ uvx hf-mem --model-id MiniMaxAI/MiniMax-M2
 uvx hf-mem --model-id Qwen/Qwen-Image
 ```
 
-<img src="https://github.com/user-attachments/assets/7a260369-26b2-48e1-a97b-f18cc72f7475" />
+<img src="https://huggingface.co/datasets/alvarobartt/hf-mem/resolve/main/diffusers.png" />
 
 #### Sentence Transformers
 
@@ -37,7 +37,7 @@ uvx hf-mem --model-id Qwen/Qwen-Image
 uvx hf-mem --model-id google/embeddinggemma-300m
 ```
 
-<img src="https://github.com/user-attachments/assets/aef1ddd8-96c2-4944-83e2-57171ff6ac7a" />
+<img src="https://huggingface.co/datasets/alvarobartt/hf-mem/resolve/main/sentence-transformers.png" />
 
 ### Python
 
@@ -69,7 +69,7 @@ By enabling the `--experimental` flag, you can enable the KV Cache memory estima
 uvx hf-mem --model-id MiniMaxAI/MiniMax-M2 --experimental
 ```
 
-<img src="https://github.com/user-attachments/assets/ec0ef39d-0323-4616-bba5-6a18ffee211c" />
+<img src="https://huggingface.co/datasets/alvarobartt/hf-mem/resolve/main/experimental.png" />
 
 ## GGUF
 
@@ -79,7 +79,7 @@ If the repository contains GGUF model weights, those will be listed by default (
 uvx hf-mem --model-id TheBloke/deepseek-llm-7B-chat-GGUF --experimental
 ```
 
-<img src="https://github.com/user-attachments/assets/b5514d35-f9c4-4a07-a719-a0185ff1dd9f" />
+<img src="https://huggingface.co/datasets/alvarobartt/hf-mem/resolve/main/gguf.png" />
 
 Or if you want to only get the estimation on a given file:
 
@@ -87,7 +87,7 @@ Or if you want to only get the estimation on a given file:
 uvx hf-mem --model-id TheBloke/deepseek-llm-7B-chat-GGUF --gguf-file deepseek-llm-7b-chat.Q2_K.gguf --experimental
 ```
 
-<img src="https://github.com/user-attachments/assets/e32ad635-05e5-4b33-b35b-3e689215dedd" />
+<img src="https://huggingface.co/datasets/alvarobartt/hf-mem/resolve/main/gguf-file.png" />
 
 ## Skills
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ More information can be found at [Anthropic Agent Skills and how to use them](ht
 
 ## Extensions
 
-Optionally, you can also add `hf-mem` as an extension to the Hugging Face Hub CLI, to include `hf-mem` as an entrypoint under the `hf` CLI. First you need to install the Hugging Face CLI, `hf`, as explained in [Hugging Face CLI - "Getting started"](https://huggingface.co/docs/huggingface_hub/en/guides/cli).To add `hf-mem` as an extension, all you need to do is run:
+Optionally, you can also add `hf-mem` as an extension to the Hugging Face Hub CLI under `hf` as `hf mem ...`. First you need to install `hf` as explained in [Hugging Face CLI - "Getting started"](https://huggingface.co/docs/huggingface_hub/en/guides/cli). To add `hf-mem` as an extension, all you need to do is run:
 
 ```bash
 hf extensions add alvarobartt/hf-mem

--- a/README.md
+++ b/README.md
@@ -89,20 +89,19 @@ uvx hf-mem --model-id TheBloke/deepseek-llm-7B-chat-GGUF --gguf-file deepseek-ll
 
 <img src="https://github.com/user-attachments/assets/e32ad635-05e5-4b33-b35b-3e689215dedd" />
 
-## (Optional) Agent Skills
+## Skills
 
 Optionally, you can add `hf-mem` as an agent skill, which allows the underlying coding agent to discover and use it when provided as a [`SKILL.md`](skills/hf-mem/SKILL.md), e.g., `.claude/skills/hf-mem/SKILL.md`.
 
 More information can be found at [Anthropic Agent Skills and how to use them](https://github.com/anthropics/skills).
 
-## References
+## Extensions
 
-### Technical
+Optionally, you can also add `hf-mem` as an extension to the Hugging Face Hub CLI, so as to unify all the Hugging Face CLIs around the `hf ...` entrypoint. To add `hf-mem` as an extension, all you need to do is run `pip install huggingface_hub --upgrade` and then `hf extensions add alvarobartt/hf-mem`, which will install `hf-mem` to be used as `hf mem ...` along with the rest of Hugging Face extensions you have installed, that you can list via `hf extensions list`. More information can be found in [the Hugging Face Hub CLI documentation](https://huggingface.co/docs/huggingface_hub/en/guides/cli-extensions#how-python-extensions-are-installed).
+
+## References
 
 - [Safetensors Metadata parsing](https://huggingface.co/docs/safetensors/en/metadata_parsing)
 - [GGUF File format](https://github.com/ggml-org/ggml/blob/master/docs/gguf.md)
 - [GGUF on the Hugging Face Hub](https://huggingface.co/docs/hub/en/gguf)
-
-### Visual
-
 - [usgraphics - TR-100 Machine Report](https://github.com/usgraphics/usgc-machine-report)

--- a/README.md
+++ b/README.md
@@ -97,7 +97,14 @@ More information can be found at [Anthropic Agent Skills and how to use them](ht
 
 ## Extensions
 
-Optionally, you can also add `hf-mem` as an extension to the Hugging Face Hub CLI, so as to unify all the Hugging Face CLIs around the `hf ...` entrypoint. To add `hf-mem` as an extension, all you need to do is run `pip install huggingface_hub --upgrade` and then `hf extensions add alvarobartt/hf-mem`, which will install `hf-mem` to be used as `hf mem ...` along with the rest of Hugging Face extensions you have installed, that you can list via `hf extensions list`. More information can be found in [the Hugging Face Hub CLI documentation](https://huggingface.co/docs/huggingface_hub/en/guides/cli-extensions#how-python-extensions-are-installed).
+Optionally, you can also add `hf-mem` as an extension to the Hugging Face Hub CLI, to include `hf-mem` as an entrypoint under the `hf` CLI. First you need to install the Hugging Face CLI, `hf`, as explained in [Hugging Face CLI - "Getting started"](https://huggingface.co/docs/huggingface_hub/en/guides/cli).To add `hf-mem` as an extension, all you need to do is run:
+
+```bash
+hf extensions add alvarobartt/hf-mem
+```
+More information can be found at [Hugging Face Hub CLI - "How Python extensions are installed"](https://huggingface.co/docs/huggingface_hub/en/guides/cli-extensions#how-python-extensions-are-installed).
+
+Once installed, you can use `hf-mem` via `hf` as `hf mem ...` along with the rest of Hugging Face extensions you have installed (which you can list via `hf extensions list`).
 
 ## References
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hf-mem"
-version = "0.5.2"
+version = "0.5.3"
 description = "A CLI to estimate inference memory requirements for Hugging Face models, written in Python."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -88,7 +88,7 @@ wheels = [
 
 [[package]]
 name = "hf-mem"
-version = "0.5.2"
+version = "0.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", extra = ["http2"] },


### PR DESCRIPTION
## Description

This PR bumps the `hf-mem` version to v0.5.3 to incorporate the latest fixes around the KV cache estimation with different precisions and quantization schemes, thanks to community contributions. This PR also adds a small section in the `README.md` on how to install `hf-mem` as a `hf` extension.

Additionally, this PR also moves all the images from being hosted by GitHub private URLs (intended for attachments) to a public image dataset in the Hugging Face Hub at https://huggingface.co/datasets/alvarobartt/hf-mem.

---

- [x] I have read and followed the guidelines in [`CONTRIBUTING.md`](/CONTRIBUTING.md).
- [x] This has been discussed over an issue or discussion.
