### PR TITLE
Add MoE breakdown for Safetensors (experimental)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ print(result)
 
 By enabling the `--experimental` flag, you can enable the KV Cache memory estimation for LLMs (`...ForCausalLM`) and VLMs (`...ForConditionalGeneration`), even including a custom `--max-model-len` (defaults to the `config.json` default), `--batch-size` (defaults to 1), and the `--kv-cache-dtype` (defaults to `auto` which means it uses the default data type set in `config.json` under `torch_dtype` or `dtype`, or rather from `quantization_config` when applicable).
 
+Additionally, for Mixture of Experts (MoEs), the `--experimental` flag also adds a weights-only breakdown of the base model and all the experts combined.
+
 ```bash
 uvx hf-mem --model-id MiniMaxAI/MiniMax-M2 --experimental
 ```

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -19,6 +19,7 @@ def _print_result(result: Result) -> None:
             revision=result.revision,
             metadata=result.safetensors,
             kv_cache=result.kv_cache_metadata,
+            moe=result.moe_metadata,
         )
         return
 
@@ -61,7 +62,12 @@ def main() -> None:
     parser.add_argument(
         "--experimental",
         action="store_true",
-        help="Whether to enable the experimental KV Cache estimation or not. Only applies to `...ForCausalLM` and `...ForConditionalGeneration` models from Transformers.",
+        help=(
+            "Whether to enable the experimental KV Cache estimation or not. For Safetensors "
+            "MoE Transformers models it also includes a base-model-vs-experts weights "
+            "breakdown. Only applies to `...ForCausalLM` and `...ForConditionalGeneration` "
+            "models from Transformers."
+        ),
     )
     parser.add_argument(
         "--max-model-len",

--- a/src/hf_mem/run.py
+++ b/src/hf_mem/run.py
@@ -16,7 +16,12 @@ from hf_mem.gguf.fetch import fetch_gguf_with_semaphore
 from hf_mem.gguf.metadata import GGUFDtype, GGUFMetadata, merge_shards
 from hf_mem.safetensors.fetch import fetch_modules_and_dense_metadata, fetch_safetensors_metadata
 from hf_mem.safetensors.kv_cache import compute_safetensors_kv_cache_size, resolve_kv_cache_dtype
-from hf_mem.safetensors.metadata import SafetensorsMetadata, parse_safetensors_metadata
+from hf_mem.safetensors.metadata import (
+    MoEMetadata,
+    SafetensorsMetadata,
+    parse_moe_metadata,
+    parse_safetensors_metadata,
+)
 
 MAX_CONCURRENCY = int(os.getenv("MAX_WORKERS", min(32, (os.cpu_count() or 1) + 4)))
 
@@ -47,6 +52,19 @@ class Result:
     safetensors: SafetensorsMetadata | None = field(default=None, repr=False)
     gguf_files: Dict[str, GGUFMetadata] | None = field(default=None, repr=False)
     kv_cache_metadata: KvCache | None = field(default=None, repr=False)
+    moe_metadata: MoEMetadata | None = field(default=None, repr=False)
+
+    def _component_to_json(self, component: Any) -> Dict[str, Any]:
+        out = {
+            "bytes": component.bytes_count,
+            "param_count": component.param_count,
+        }
+        if self.details:
+            out["dtypes"] = {
+                dtype: {"bytes": dm.bytes_count, "param_count": dm.param_count}
+                for dtype, dm in component.dtypes.items()
+            }
+        return out
 
     def to_json(self) -> Dict[str, Any]:
         out: Dict[str, Any] = {"model_id": self.model_id}
@@ -57,6 +75,17 @@ class Result:
             out["memory"] = self.memory
             out["kv_cache"] = self.kv_cache
             out["total_memory"] = self.total_memory
+            if self.moe_metadata is not None:
+                out["moe"] = {
+                    "base_model": self._component_to_json(self.moe_metadata.base_model),
+                    "expert_count": self.moe_metadata.expert_count,
+                    "experts_total": {
+                        "bytes": self.moe_metadata.expert_bytes_count,
+                        "param_count": self.moe_metadata.expert_param_count,
+                    },
+                    "experts": self._component_to_json(self.moe_metadata.expert_template),
+                    "active_expert_count": self.moe_metadata.active_expert_count,
+                }
             return out
 
         if self.safetensors is not None:
@@ -84,6 +113,17 @@ class Result:
                 if self.kv_cache_metadata is not None
                 else None
             )
+            if self.moe_metadata is not None:
+                out["moe"] = {
+                    "base_model": self._component_to_json(self.moe_metadata.base_model),
+                    "expert_count": self.moe_metadata.expert_count,
+                    "experts_total": {
+                        "bytes": self.moe_metadata.expert_bytes_count,
+                        "param_count": self.moe_metadata.expert_param_count,
+                    },
+                    "experts": self._component_to_json(self.moe_metadata.expert_template),
+                    "active_expert_count": self.moe_metadata.active_expert_count,
+                }
 
         elif self.gguf_files is not None:
             if self.filename is not None:
@@ -444,6 +484,7 @@ async def arun(
         )
 
     kv_cache_cls: KvCache | None = None
+    moe_metadata: MoEMetadata | None = None
     if experimental and "config.json" in file_paths:
         url = f"https://huggingface.co/{model_id}/resolve/{revision}/config.json"
         config: Dict[str, Any] = await get_json_file(client, url, headers)
@@ -479,6 +520,8 @@ async def arun(
                         text_config[key] = config[key]
 
                 config = text_config
+
+            moe_metadata = parse_moe_metadata(raw_metadata=raw_metadata, config=config)
 
             if max_model_len is None:
                 max_model_len = config.get(
@@ -525,6 +568,7 @@ async def arun(
         details=details,
         safetensors=metadata,
         kv_cache_metadata=kv_cache_cls,
+        moe_metadata=moe_metadata,
     )
 
 

--- a/src/hf_mem/safetensors/__init__.py
+++ b/src/hf_mem/safetensors/__init__.py
@@ -3,7 +3,9 @@ from hf_mem.safetensors.kv_cache import compute_safetensors_kv_cache_size, resol
 from hf_mem.safetensors.metadata import (
     ComponentMetadata,
     DtypeMetadata,
+    MoEMetadata,
     SafetensorsMetadata,
+    parse_moe_metadata,
     parse_safetensors_metadata,
 )
 from hf_mem.safetensors.print import print_safetensors_report
@@ -23,7 +25,9 @@ __all__ = [
     # metadata
     "DtypeMetadata",
     "ComponentMetadata",
+    "MoEMetadata",
     "SafetensorsMetadata",
+    "parse_moe_metadata",
     "parse_safetensors_metadata",
     # fetch
     "get_json_file",

--- a/src/hf_mem/safetensors/metadata.py
+++ b/src/hf_mem/safetensors/metadata.py
@@ -25,6 +25,151 @@ class SafetensorsMetadata:
     bytes_count: int
 
 
+@dataclass
+class MoEMetadata:
+    base_model: ComponentMetadata
+    experts: Dict[int, ComponentMetadata]
+    expert_count: int
+    active_expert_count: int | None
+    expert_param_count: int
+    expert_bytes_count: int
+    expert_template: ComponentMetadata
+
+
+def _accumulate_tensor(
+    component: ComponentMetadata,
+    *,
+    dtype: SafetensorsDtypes | str,
+    shape: Any,
+) -> tuple[int, int]:
+    if dtype not in component.dtypes:
+        component.dtypes[dtype] = DtypeMetadata(param_count=0, bytes_count=0)
+
+    dtype_bytes = get_safetensors_dtype_bytes(dtype)
+    current_shape = math.prod(shape)
+    current_shape_bytes = current_shape * dtype_bytes
+
+    component.dtypes[dtype].param_count += current_shape
+    component.dtypes[dtype].bytes_count += current_shape_bytes
+    component.param_count += current_shape
+    component.bytes_count += current_shape_bytes
+    return current_shape, current_shape_bytes
+
+
+def _extract_expert_id(tensor_name: str) -> int | None:
+    expert_tokens = {
+        "expert",
+        "experts",
+        "local_expert",
+        "local_experts",
+        "routed_expert",
+        "routed_experts",
+    }
+    parts = tensor_name.split(".")
+    for idx, part in enumerate(parts):
+        if part in expert_tokens and idx + 1 < len(parts) and parts[idx + 1].isdigit():
+            return int(parts[idx + 1])
+
+    return None
+
+
+def _get_config_int(config: Dict[str, Any], *keys: str) -> int | None:
+    for key in keys:
+        value = config.get(key)
+        if isinstance(value, int) and value > 1:
+            return value
+    return None
+
+
+def _components_match(component1: ComponentMetadata, component2: ComponentMetadata) -> bool:
+    if component1.param_count != component2.param_count or component1.bytes_count != component2.bytes_count:
+        return False
+    if component1.dtypes.keys() != component2.dtypes.keys():
+        return False
+    return all(
+        component1.dtypes[dtype].param_count == component2.dtypes[dtype].param_count
+        and component1.dtypes[dtype].bytes_count == component2.dtypes[dtype].bytes_count
+        for dtype in component1.dtypes
+    )
+
+
+def parse_moe_metadata(
+    raw_metadata: Dict[str, Dict[str, Any]],
+    config: Dict[str, Any],
+) -> MoEMetadata | None:
+    configured_expert_count = _get_config_int(
+        config,
+        "num_local_experts",
+        "n_routed_experts",
+        "num_experts",
+        "moe_num_experts",
+    )
+    active_expert_count = _get_config_int(
+        config,
+        "num_experts_per_tok",
+        "num_experts_per_token",
+        "top_k",
+    )
+
+    base_model = ComponentMetadata(dtypes={}, param_count=0, bytes_count=0)
+    experts: Dict[int, ComponentMetadata] = {}
+
+    for metadata in raw_metadata.values():
+        for tensor_name, value in metadata.items():
+            if tensor_name == "__metadata__":
+                continue
+
+            expert_id = _extract_expert_id(tensor_name)
+            target = base_model
+            if expert_id is not None:
+                if expert_id not in experts:
+                    experts[expert_id] = ComponentMetadata(dtypes={}, param_count=0, bytes_count=0)
+                target = experts[expert_id]
+
+            _accumulate_tensor(
+                target,
+                dtype=value["dtype"],
+                shape=value["shape"],
+            )
+
+    if not experts:
+        return None
+
+    observed_ids = sorted(experts)
+    observed_expert_count = len(observed_ids)
+    if configured_expert_count is not None:
+        expected_ids = list(range(configured_expert_count))
+        if observed_ids != expected_ids:
+            raise RuntimeError(
+                "MoE expert indices inferred from the Safetensors metadata do not match the "
+                f"`config.json` expert count. Expected IDs {expected_ids[:3]}...{expected_ids[-3:]} "
+                f"(count={configured_expert_count}), found IDs {observed_ids[:3]}...{observed_ids[-3:]} "
+                f"(count={observed_expert_count})."
+            )
+        expert_count = configured_expert_count
+    else:
+        expert_count = observed_expert_count
+
+    expert_param_count = sum(component.param_count for component in experts.values())
+    expert_bytes_count = sum(component.bytes_count for component in experts.values())
+    expert_template = experts[observed_ids[0]]
+    for expert_id in observed_ids[1:]:
+        if not _components_match(expert_template, experts[expert_id]):
+            raise RuntimeError(
+                "MoE experts inferred from the Safetensors metadata are not uniform, so they "
+                "cannot be summarized as `N x EXPERTS` safely."
+            )
+    return MoEMetadata(
+        base_model=base_model,
+        experts=dict(sorted(experts.items())),
+        expert_count=expert_count,
+        active_expert_count=active_expert_count,
+        expert_param_count=expert_param_count,
+        expert_bytes_count=expert_bytes_count,
+        expert_template=expert_template,
+    )
+
+
 def parse_safetensors_metadata(
     raw_metadata: Dict[str, Dict[str, Any]],
 ) -> SafetensorsMetadata:
@@ -37,18 +182,11 @@ def parse_safetensors_metadata(
             if key in {"__metadata__"}:
                 continue
 
-            dtype = value["dtype"]
-            if dtype not in component.dtypes:
-                component.dtypes[dtype] = DtypeMetadata(param_count=0, bytes_count=0)
-
-            dtype_bytes = get_safetensors_dtype_bytes(dtype)
-            current_shape = math.prod(value["shape"])
-            current_shape_bytes = current_shape * dtype_bytes
-
-            component.dtypes[dtype].param_count += current_shape
-            component.dtypes[dtype].bytes_count += current_shape_bytes
-            component.param_count += current_shape
-            component.bytes_count += current_shape_bytes
+            current_shape, current_shape_bytes = _accumulate_tensor(
+                component,
+                dtype=value["dtype"],
+                shape=value["shape"],
+            )
             total_param_count += current_shape
             total_bytes_count += current_shape_bytes
 

--- a/src/hf_mem/safetensors/print.py
+++ b/src/hf_mem/safetensors/print.py
@@ -14,7 +14,15 @@ from hf_mem._print import (
 )
 from hf_mem._types import KvCache
 from hf_mem._version import __version__
-from hf_mem.safetensors.metadata import SafetensorsMetadata
+from hf_mem.safetensors.metadata import MoEMetadata, SafetensorsMetadata
+
+
+def _sorted_dtypes(component) -> list[tuple[str, object]]:
+    return sorted(
+        component.dtypes.items(),
+        key=lambda item: item[1].bytes_count,
+        reverse=True,
+    )
 
 
 def print_safetensors_report(
@@ -22,8 +30,10 @@ def print_safetensors_report(
     revision: str,
     metadata: SafetensorsMetadata,
     kv_cache: KvCache | None = None,
+    moe: MoEMetadata | None = None,
 ) -> None:
     combined_total = metadata.bytes_count + kv_cache.cache_size if kv_cache else metadata.bytes_count
+    model_total = metadata.bytes_count
 
     centered_rows = [
         "INFERENCE MEMORY ESTIMATE FOR",
@@ -44,6 +54,18 @@ def print_safetensors_report(
         centered_rows.append(
             f"KV CACHE ({kv_cache.max_model_len * kv_cache.batch_size} TOKENS, {_bytes_to_gib(kv_cache.cache_size):.2f} GiB)"
         )
+    if moe:
+        moe_rows = [
+            (
+                f"MODEL ({_format_short_number(moe.base_model.param_count)} PARAMS, "
+                f"{_bytes_to_gib(moe.base_model.bytes_count):.2f} GiB)"
+            ),
+            (
+                f"{moe.expert_count} x EXPERTS ({_format_short_number(moe.expert_template.param_count)} PARAMS EACH, "
+                f"{_bytes_to_gib(moe.expert_template.bytes_count):.2f} GiB EACH)"
+            ),
+        ]
+        centered_rows.extend(moe_rows)
 
     data_rows = []
     if kv_cache:
@@ -58,6 +80,22 @@ def print_safetensors_report(
         for _, dtype_metadata in nested_metadata.dtypes.items():
             data_rows.append(
                 f"{_bytes_to_gib(dtype_metadata.bytes_count):.2f} / {_bytes_to_gib(combined_total):.2f} GiB"
+            )
+    if moe:
+        data_rows.append(
+            f"{_bytes_to_gib(moe.base_model.bytes_count):.2f} / {_bytes_to_gib(model_total):.2f} GiB"
+        )
+        data_rows.append(f"{_bytes_to_gib(moe.expert_bytes_count):.2f} / {_bytes_to_gib(model_total):.2f} GiB")
+        data_rows.append(
+            f"{_bytes_to_gib(moe.expert_template.bytes_count):.2f} / {_bytes_to_gib(model_total):.2f} GiB"
+        )
+        for _, dtype_metadata in _sorted_dtypes(moe.base_model):
+            data_rows.append(
+                f"{_bytes_to_gib(dtype_metadata.bytes_count):.2f} / {_bytes_to_gib(model_total):.2f} GiB"
+            )
+        for _, dtype_metadata in _sorted_dtypes(moe.expert_template):
+            data_rows.append(
+                f"{_bytes_to_gib(dtype_metadata.bytes_count):.2f} / {_bytes_to_gib(model_total):.2f} GiB"
             )
     if kv_cache:
         data_rows.append(f"{_bytes_to_gib(kv_cache.cache_size):.2f} / {_bytes_to_gib(combined_total):.2f} GiB")
@@ -87,18 +125,87 @@ def print_safetensors_report(
     _print_divider(data_col_width + 1, "top")
 
     if kv_cache:
-        total_text = f"{_bytes_to_gib(combined_total):.2f} GiB ({_format_short_number(metadata.param_count)} PARAMS + KV CACHE)"
+        total_text = (
+            f"{_bytes_to_gib(combined_total):.2f} GiB "
+            f"({_format_short_number(metadata.param_count)} PARAMS + KV CACHE)"
+        )
         total_bar = _make_bar(combined_total, combined_total, data_col_width)
         _print_row("TOTAL MEMORY", total_text, data_col_width)
         _print_row("REQUIREMENTS", total_bar, data_col_width)
     else:
-        model_text = f"{_bytes_to_gib(metadata.bytes_count):.2f} GiB ({_format_short_number(metadata.param_count)} PARAMS)"
+        model_text = (
+            f"{_bytes_to_gib(metadata.bytes_count):.2f} GiB "
+            f"({_format_short_number(metadata.param_count)} PARAMS)"
+        )
         model_bar = _make_bar(metadata.bytes_count, metadata.bytes_count, data_col_width)
         _print_row("TOTAL MEMORY", model_text, data_col_width)
         _print_row("REQUIREMENTS", model_bar, data_col_width)
 
     max_length = 0
     for key, value in metadata.components.items():
+        if moe and len(metadata.components) == 1:
+            max_length = max(
+                len(f"{_format_short_number(dtype_metadata.param_count)} PARAMS")
+                for _, dtype_metadata in _sorted_dtypes(moe.base_model)
+            )
+            max_length = max(
+                max_length,
+                max(
+                    len(f"{_format_short_number(dtype_metadata.param_count)} PARAMS")
+                    for _, dtype_metadata in _sorted_dtypes(moe.expert_template)
+                ),
+            )
+
+            _print_divider(data_col_width + 1, "top-continue")
+            _print_centered(
+                f"MODEL ({_format_short_number(moe.base_model.param_count)} PARAMS, {_bytes_to_gib(moe.base_model.bytes_count):.2f} GiB)",
+                current_len,
+            )
+            _print_divider(data_col_width + 1, "top")
+            for idx, (dtype, dtype_metadata) in enumerate(_sorted_dtypes(moe.base_model)):
+                gib_text = (
+                    f"{_bytes_to_gib(dtype_metadata.bytes_count):.2f} / {_bytes_to_gib(model_total):.2f} GiB"
+                )
+                _print_row(
+                    dtype.upper() + " " * (max_length - len(dtype)),
+                    gib_text,
+                    data_col_width,
+                )
+                _print_row(
+                    f"{_format_short_number(dtype_metadata.param_count)} PARAMS",
+                    _make_bar(dtype_metadata.bytes_count, model_total, data_col_width),
+                    data_col_width,
+                )
+                if idx < len(moe.base_model.dtypes) - 1:
+                    _print_divider(data_col_width + 1)
+
+            _print_divider(data_col_width + 1, "top-continue")
+            _print_centered(
+                (
+                    f"{moe.expert_count} x EXPERTS ({_format_short_number(moe.expert_template.param_count)} PARAMS EACH, "
+                    f"{_bytes_to_gib(moe.expert_template.bytes_count):.2f} GiB EACH)"
+                ),
+                current_len,
+            )
+            _print_divider(data_col_width + 1, "top")
+            for idx, (dtype, dtype_metadata) in enumerate(_sorted_dtypes(moe.expert_template)):
+                gib_text = (
+                    f"{_bytes_to_gib(dtype_metadata.bytes_count):.2f} / {_bytes_to_gib(model_total):.2f} GiB"
+                )
+                _print_row(
+                    dtype.upper() + " " * (max_length - len(dtype)),
+                    gib_text,
+                    data_col_width,
+                )
+                _print_row(
+                    f"{_format_short_number(dtype_metadata.param_count)} PARAMS",
+                    _make_bar(dtype_metadata.bytes_count, model_total, data_col_width),
+                    data_col_width,
+                )
+                if idx < len(moe.expert_template.dtypes) - 1:
+                    _print_divider(data_col_width + 1)
+            continue
+
         if len(metadata.components) > 1:
             _print_divider(data_col_width + 1, "top-continue")
             _print_centered(
@@ -120,7 +227,7 @@ def print_safetensors_report(
             len(f"{_format_short_number(dtype_metadata.param_count)} PARAMS")
             for _, dtype_metadata in value.dtypes.items()
         )
-        for idx, (dtype, dtype_metadata) in enumerate(value.dtypes.items()):
+        for idx, (dtype, dtype_metadata) in enumerate(_sorted_dtypes(value)):
             gib_text = (
                 f"{_bytes_to_gib(dtype_metadata.bytes_count):.2f} / {_bytes_to_gib(combined_total):.2f} GiB"
             )


### PR DESCRIPTION
## Description

This PR adds an experimental MoE breakdown of the weights so that rather than providing a memory estimation on all the weights as in a dense model, those are rather displayed separately for the base model and the experts, which provides more information and useful insights on the model requirements towards setting one parallelism strategy or the other.

As it's still experimental and subject to change is included under the `--experimental` flag for the time being, see an example below:

![](https://huggingface.co/datasets/alvarobartt/hf-mem/resolve/refs%2Fpr%2F2/experimental.png)

---

- [x] I have read and followed the guidelines in [`CONTRIBUTING.md`](/CONTRIBUTING.md).
- [ ] This has been discussed over an issue or discussion.
