### PR TITLE
Fix `sliding_window` assignment

### DIFF
--- a/src/hf_mem/safetensors/kv_cache.py
+++ b/src/hf_mem/safetensors/kv_cache.py
@@ -162,7 +162,7 @@ def compute_safetensors_kv_cache_size(
     # per-layer token counts (`max_model_len` for full-attention, `min(sliding_window, max_model_len)`
     # for sliding-window) instead of multiplying a single layer count by `max_model_len`.
     num_full_layers, num_sliding_layers = _resolve_attention_layer_counts(config)
-    sliding_window: int = config.get("sliding_window", max_model_len)
+    sliding_window = config.get("sliding_window") or max_model_len
     total_kv_tokens = num_full_layers * max_model_len + num_sliding_layers * min(sliding_window, max_model_len)
 
     return (


### PR DESCRIPTION
## Description

This PR fixes the `sliding_window` assignment on the KV cache calculation, as it was wrongly `config.get("sliding_window", max_model_len)` which only works if the key `sliding_window` is not in the `config` in which case it fallback to `max_model_len`; but if the `sliding_window` key is set but set to `null`, then it will be assigned as `None` and won't default to the fallback value.

---

- [x] I have read and followed the guidelines in [`CONTRIBUTING.md`](/CONTRIBUTING.md).
- [ ] This has been discussed over an issue or discussion.
