### PR TITLE
Fix `--experimental` display for expert dtypes in MoEs

### DIFF
--- a/src/hf_mem/safetensors/metadata.py
+++ b/src/hf_mem/safetensors/metadata.py
@@ -34,6 +34,7 @@ class MoEMetadata:
     expert_param_count: int
     expert_bytes_count: int
     expert_template: ComponentMetadata
+    expert_display_template: ComponentMetadata
 
 
 def _accumulate_tensor(
@@ -93,6 +94,10 @@ def _components_match(component1: ComponentMetadata, component2: ComponentMetada
     )
 
 
+def _is_expert_weight_tensor(tensor_name: str) -> bool:
+    return tensor_name.endswith(".weight")
+
+
 def parse_moe_metadata(
     raw_metadata: Dict[str, Dict[str, Any]],
     config: Dict[str, Any],
@@ -113,6 +118,7 @@ def parse_moe_metadata(
 
     base_model = ComponentMetadata(dtypes={}, param_count=0, bytes_count=0)
     experts: Dict[int, ComponentMetadata] = {}
+    expert_display_components: Dict[int, ComponentMetadata] = {}
 
     for metadata in raw_metadata.values():
         for tensor_name, value in metadata.items():
@@ -124,6 +130,9 @@ def parse_moe_metadata(
             if expert_id is not None:
                 if expert_id not in experts:
                     experts[expert_id] = ComponentMetadata(dtypes={}, param_count=0, bytes_count=0)
+                    expert_display_components[expert_id] = ComponentMetadata(
+                        dtypes={}, param_count=0, bytes_count=0
+                    )
                 target = experts[expert_id]
 
             _accumulate_tensor(
@@ -131,6 +140,12 @@ def parse_moe_metadata(
                 dtype=value["dtype"],
                 shape=value["shape"],
             )
+            if expert_id is not None and _is_expert_weight_tensor(tensor_name):
+                _accumulate_tensor(
+                    expert_display_components[expert_id],
+                    dtype=value["dtype"],
+                    shape=value["shape"],
+                )
 
     if not experts:
         return None
@@ -153,11 +168,17 @@ def parse_moe_metadata(
     expert_param_count = sum(component.param_count for component in experts.values())
     expert_bytes_count = sum(component.bytes_count for component in experts.values())
     expert_template = experts[observed_ids[0]]
+    expert_display_template = expert_display_components[observed_ids[0]]
     for expert_id in observed_ids[1:]:
         if not _components_match(expert_template, experts[expert_id]):
             raise RuntimeError(
                 "MoE experts inferred from the Safetensors metadata are not uniform, so they "
                 "cannot be summarized as `N x EXPERTS` safely."
+            )
+        if not _components_match(expert_display_template, expert_display_components[expert_id]):
+            raise RuntimeError(
+                "MoE expert weight tensors inferred from the Safetensors metadata are not uniform, "
+                "so their dtype breakdown cannot be summarized as `N x EXPERTS` safely."
             )
     return MoEMetadata(
         base_model=base_model,
@@ -167,6 +188,7 @@ def parse_moe_metadata(
         expert_param_count=expert_param_count,
         expert_bytes_count=expert_bytes_count,
         expert_template=expert_template,
+        expert_display_template=expert_display_template,
     )
 
 

--- a/src/hf_mem/safetensors/print.py
+++ b/src/hf_mem/safetensors/print.py
@@ -34,6 +34,8 @@ def print_safetensors_report(
 ) -> None:
     combined_total = metadata.bytes_count + kv_cache.cache_size if kv_cache else metadata.bytes_count
     model_total = metadata.bytes_count
+    moe_base_dtypes = _sorted_dtypes(moe.base_model) if moe is not None else []
+    moe_expert_dtypes = _sorted_dtypes(moe.expert_display_template) if moe is not None else []
 
     centered_rows = [
         "INFERENCE MEMORY ESTIMATE FOR",
@@ -76,27 +78,24 @@ def print_safetensors_report(
         data_rows.append(
             f"{_bytes_to_gib(metadata.bytes_count):.2f} GiB ({_format_short_number(metadata.param_count)} PARAMS)"
         )
-    for _, nested_metadata in metadata.components.items():
-        for _, dtype_metadata in nested_metadata.dtypes.items():
-            data_rows.append(
-                f"{_bytes_to_gib(dtype_metadata.bytes_count):.2f} / {_bytes_to_gib(combined_total):.2f} GiB"
-            )
     if moe:
         data_rows.append(
             f"{_bytes_to_gib(moe.base_model.bytes_count):.2f} / {_bytes_to_gib(model_total):.2f} GiB"
         )
-        data_rows.append(f"{_bytes_to_gib(moe.expert_bytes_count):.2f} / {_bytes_to_gib(model_total):.2f} GiB")
-        data_rows.append(
-            f"{_bytes_to_gib(moe.expert_template.bytes_count):.2f} / {_bytes_to_gib(model_total):.2f} GiB"
-        )
-        for _, dtype_metadata in _sorted_dtypes(moe.base_model):
+        for _, dtype_metadata in moe_base_dtypes:
             data_rows.append(
                 f"{_bytes_to_gib(dtype_metadata.bytes_count):.2f} / {_bytes_to_gib(model_total):.2f} GiB"
             )
-        for _, dtype_metadata in _sorted_dtypes(moe.expert_template):
+        for _, dtype_metadata in moe_expert_dtypes:
             data_rows.append(
                 f"{_bytes_to_gib(dtype_metadata.bytes_count):.2f} / {_bytes_to_gib(model_total):.2f} GiB"
             )
+    else:
+        for _, nested_metadata in metadata.components.items():
+            for _, dtype_metadata in nested_metadata.dtypes.items():
+                data_rows.append(
+                    f"{_bytes_to_gib(dtype_metadata.bytes_count):.2f} / {_bytes_to_gib(combined_total):.2f} GiB"
+                )
     if kv_cache:
         data_rows.append(f"{_bytes_to_gib(kv_cache.cache_size):.2f} / {_bytes_to_gib(combined_total):.2f} GiB")
 
@@ -146,13 +145,13 @@ def print_safetensors_report(
         if moe and len(metadata.components) == 1:
             max_length = max(
                 len(f"{_format_short_number(dtype_metadata.param_count)} PARAMS")
-                for _, dtype_metadata in _sorted_dtypes(moe.base_model)
+                for _, dtype_metadata in moe_base_dtypes
             )
             max_length = max(
                 max_length,
                 max(
                     len(f"{_format_short_number(dtype_metadata.param_count)} PARAMS")
-                    for _, dtype_metadata in _sorted_dtypes(moe.expert_template)
+                    for _, dtype_metadata in moe_expert_dtypes
                 ),
             )
 
@@ -162,7 +161,7 @@ def print_safetensors_report(
                 current_len,
             )
             _print_divider(data_col_width + 1, "top")
-            for idx, (dtype, dtype_metadata) in enumerate(_sorted_dtypes(moe.base_model)):
+            for idx, (dtype, dtype_metadata) in enumerate(moe_base_dtypes):
                 gib_text = (
                     f"{_bytes_to_gib(dtype_metadata.bytes_count):.2f} / {_bytes_to_gib(model_total):.2f} GiB"
                 )
@@ -188,7 +187,7 @@ def print_safetensors_report(
                 current_len,
             )
             _print_divider(data_col_width + 1, "top")
-            for idx, (dtype, dtype_metadata) in enumerate(_sorted_dtypes(moe.expert_template)):
+            for idx, (dtype, dtype_metadata) in enumerate(moe_expert_dtypes):
                 gib_text = (
                     f"{_bytes_to_gib(dtype_metadata.bytes_count):.2f} / {_bytes_to_gib(model_total):.2f} GiB"
                 )


### PR DESCRIPTION
## Description

This PR fixes the `--experimental` display for MoEs as the experts were including the dtypes that were identified when reading the Safetensors metadata, rather than only the dtypes of the expert weights.

---

- [x] I have read and followed the guidelines in [`CONTRIBUTING.md`](/CONTRIBUTING.md).
- [ ] This has been discussed over an issue or discussion.
