### PR TITLE
Add warmup peak memory estimation via `--max-num-batched-tokens`

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ uvx hf-mem --model-id meta-llama/Llama-3.1-8B-Instruct --max-num-batched-tokens 
 
 This flag is **independent of `--experimental`**: it works for any supported architecture (causal LMs, masked LMs, sequence/token classifiers, base encoders, Sentence Transformers) without needing the experimental gate. The existing `--batch-size` is reused as `max_num_seqs` to size the LM head spike. GGUF files are not supported — the flag is silently ignored when combined with `--gguf-file`.
 
-The estimate models PyTorch's caching-allocator behavior (persistent residual stream + largest transient) from `config.json` fields. It excludes runtime-discovered components such as NCCL buffers and FlashAttention kernel workspaces, so the real-world peak may be 10-30% higher.
+This estimation mimics PyTorch's caching-allocator behavior (persistent residual stream + largest transient), inferred from `config.json`. It excludes runtime-discovered components such as NCCL buffers or FlashAttention kernels, among others. Bear that in mind as the real-world peak may be ~10 to 30 percent higher.
 
 ## GGUF
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,10 @@ By passing `--max-num-batched-tokens`, you can also estimate the **peak activati
 uvx hf-mem --model-id meta-llama/Llama-3.1-8B-Instruct --max-num-batched-tokens 8192
 ```
 
-This flag is **independent of `--experimental`**: it works for any supported architecture (causal LMs, masked LMs, sequence/token classifiers, base encoders, Sentence Transformers) without needing the experimental gate. The existing `--batch-size` is reused as `max_num_seqs` to size the LM head spike. GGUF files are not supported — the flag is silently ignored when combined with `--gguf-file`.
+`--max-num-batched-tokens` works for any of CLM, MLM, SeqCls, TokCls, Encoders, or Sentence Transformers. It can be combined along with `--batch-size`, which is interpreted as `max_num_seqs` to size the language model head spike.
+
+> [!WARNING]
+> This estimation just applies for Safetensors models and not GGUF.
 
 This estimation mimics PyTorch's caching-allocator behavior (persistent residual stream + largest transient), inferred from `config.json`. It excludes runtime-discovered components such as NCCL buffers or FlashAttention kernels, among others. Bear that in mind as the real-world peak may be ~10 to 30 percent higher.
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ uvx hf-mem --model-id MiniMaxAI/MiniMax-M2 --experimental
 
 ## Warmup peak memory
 
-By passing `--max-num-batched-tokens`, you can estimate the **peak activation memory** during a single warmup forward pass — analogous to what vLLM measures in its `profile_run` at startup or what TEI measures during its warmup. This is the third memory component reported alongside weights and KV cache, and is included in `total_memory`.
+By passing `--max-num-batched-tokens`, you can also estimate the **peak activation memory** during a single warmup forward pass, analogous to what vLLM measures in its `profile_run` at startup or what Text Embeddings Inference measures during its warmup phase..
 
 ```bash
 uvx hf-mem --model-id meta-llama/Llama-3.1-8B-Instruct --max-num-batched-tokens 8192

--- a/README.md
+++ b/README.md
@@ -73,6 +73,18 @@ uvx hf-mem --model-id MiniMaxAI/MiniMax-M2 --experimental
 
 <img src="https://huggingface.co/datasets/alvarobartt/hf-mem/resolve/main/experimental.png" />
 
+## Warmup peak memory
+
+By passing `--max-num-batched-tokens`, you can estimate the **peak activation memory** during a single warmup forward pass — analogous to what vLLM measures in its `profile_run` at startup or what TEI measures during its warmup. This is the third memory component reported alongside weights and KV cache, and is included in `total_memory`.
+
+```bash
+uvx hf-mem --model-id meta-llama/Llama-3.1-8B-Instruct --max-num-batched-tokens 8192
+```
+
+This flag is **independent of `--experimental`**: it works for any supported architecture (causal LMs, masked LMs, sequence/token classifiers, base encoders, Sentence Transformers) without needing the experimental gate. The existing `--batch-size` is reused as `max_num_seqs` to size the LM head spike. GGUF files are not supported — the flag is silently ignored when combined with `--gguf-file`.
+
+The estimate models PyTorch's caching-allocator behavior (persistent residual stream + largest transient) from `config.json` fields. It excludes runtime-discovered components such as NCCL buffers and FlashAttention kernel workspaces, so the real-world peak may be 10-30% higher.
+
 ## GGUF
 
 If the repository contains GGUF model weights, those will be listed by default (only if there are no Safetensors weights, otherwise the GGUFs will be ignored) and the memory will be estimated for each one of those; whereas if a specific file is provided, then the memory estimation will be targeted for that given file instead.

--- a/skills/hf-mem/SKILL.md
+++ b/skills/hf-mem/SKILL.md
@@ -13,6 +13,7 @@ Estimates inference memory (model weights + optional KV cache) for models on the
 - User asks how much VRAM or memory a model needs to run
 - User wants to know if a model fits on their GPU or a given instance
 - User references a Hugging Face model ID or URL and asks about inference requirements
+- User asks about activation memory or warmup memory for a model
 
 ## Requirements
 
@@ -43,6 +44,14 @@ Adds KV cache memory on top of weights. Applies to LLMs (`...ForCausalLM`), VLMs
 uvx hf-mem --model-id <org/model> [--gguf-file <path>] \
   --experimental [--max-model-len N] [--batch-size N] \
   [--kv-cache-dtype auto|bfloat16|fp8|fp8_e4m3|fp8_e5m2]
+```
+
+## Warmup peak memory (`--max-num-batched-tokens`)
+
+Estimates peak activation memory during a single warmup forward pass (vLLM `profile_run` / TEI warmup analog). Works for causal LMs, VLMs, masked LMs, sequence/token classifiers, base encoders, and Sentence Transformers. Independent of `--experimental`. Reuses `--batch-size` as `max_num_seqs`. Not supported for GGUF.
+
+```bash
+uvx hf-mem --model-id <org/model> --max-num-batched-tokens 8192 [--batch-size N]
 ```
 
 ## Examples

--- a/src/hf_mem/_types.py
+++ b/src/hf_mem/_types.py
@@ -7,3 +7,11 @@ class KvCache:
     cache_size: int
     batch_size: int
     cache_dtype: str | None = None
+
+
+@dataclass
+class WarmupPeak:
+    max_num_batched_tokens: int
+    max_num_seqs: int
+    peak_bytes: int
+    activation_dtype: str | None = None

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -80,7 +80,24 @@ def main() -> None:
         "--batch-size",
         type=int,
         default=1,
-        help="Batch size to help estimate the required RAM for caching when running the inference. Defaults to 1.",
+        help=(
+            "Concurrent sequence count. Used for both KV cache sizing "
+            "(under --experimental) and as the `max_num_seqs` cap for the warmup peak "
+            "LM head spike (when --max-num-batched-tokens is set). Defaults to 1."
+        ),
+    )
+    parser.add_argument(
+        "--max-num-batched-tokens",
+        type=int,
+        default=None,
+        # NOTE: https://docs.vllm.ai/en/stable/configuration/engine_args/#-max-num-batched-tokens
+        help=(
+            "Total tokens in a batched warmup forward pass. When set, hf-mem computes "
+            "an activation-peak memory estimate analogous to vLLM's profile_run / TEI's "
+            "warmup. For LM head sizing, --batch-size is reused as max_num_seqs. Has no "
+            "effect for GGUF files. Suggested values: 8192 (vLLM online default), "
+            "16384 (TEI default). Defaults to None (skip the estimate)."
+        ),
     )
     parser.add_argument(
         "--kv-cache-dtype",
@@ -115,7 +132,13 @@ def main() -> None:
 
     if args.experimental:
         warnings.warn(
-            "`--experimental` is set, which means that models with an architecture as `...ForCausalLM` and `...ForConditionalGeneration` will include estimations for the KV Cache as well. You can also provide the args `--max-model-len` and `--batch-size` as part of the estimation. Note that enabling `--experimental` means that the output will be different both when displayed and when dumped as JSON with `--json-output`, so bear that in mind."
+            "`--experimental` is set, which means that models with an architecture as `...ForCausalLM` and `...ForConditionalGeneration` will include estimations for the KV Cache as well. You can also provide the args `--max-model-len` and `--batch-size` as part of the estimation. Note that enabling `--experimental` means that the output will be different both when displayed and when dumped as JSON with `--json-output`, so bear that in mind. Warmup peak activation memory is controlled separately via `--max-num-batched-tokens`."
+        )
+
+    if args.max_num_batched_tokens is not None and args.gguf_file is not None:
+        warnings.warn(
+            "`--max-num-batched-tokens` has no effect when combined with `--gguf-file`; "
+            "warmup peak is not computed for GGUF files."
         )
 
     if args.ignore_table_width:
@@ -139,6 +162,7 @@ def main() -> None:
             kv_cache_dtype=args.kv_cache_dtype,
             gguf_file=args.gguf_file,
             details=args.details,
+            max_num_batched_tokens=args.max_num_batched_tokens,
         )
     )
 

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -20,6 +20,7 @@ def _print_result(result: Result) -> None:
             metadata=result.safetensors,
             kv_cache=result.kv_cache_metadata,
             moe=result.moe_metadata,
+            warmup_peak=result.warmup_peak_metadata,
         )
         return
 

--- a/src/hf_mem/cli.py
+++ b/src/hf_mem/cli.py
@@ -167,6 +167,12 @@ def main() -> None:
         )
     )
 
+    if result.gguf_files is not None and args.max_num_batched_tokens is not None and args.gguf_file is None:
+        warnings.warn(
+            "`--max-num-batched-tokens` has no effect for GGUF-only repos; "
+            "warmup peak is not computed for GGUF files."
+        )
+
     if args.json_output:
         print(json.dumps(result.to_json()))
     else:

--- a/src/hf_mem/run.py
+++ b/src/hf_mem/run.py
@@ -516,10 +516,12 @@ async def arun(
         url = f"https://huggingface.co/{model_id}/resolve/{revision}/config.json"
         config: Dict[str, Any] = await get_json_file(client, url, headers)
 
-        # NOTE: For ...ForConditionalGeneration with a text_config, prefer the text config —
-        # same logic as before, just lifted out of the KV-cache-only branch.
+        # ForConditionalGeneration nests language model params under text_config; the outer
+        # config is the vision wrapper. Capture the outer architectures before any swap so
+        # the experimental arch check below sees the original list.
+        outer_architectures = config.get("architectures", [])
         if (
-            any(arch.__contains__("ForConditionalGeneration") for arch in config.get("architectures", []))
+            any(arch.__contains__("ForConditionalGeneration") for arch in outer_architectures)
             and "text_config" in config
         ):
             warnings.warn(
@@ -545,7 +547,7 @@ async def arun(
         if experimental:
             if not any(
                 arch.__contains__("ForCausalLM") or arch.__contains__("ForConditionalGeneration")
-                for arch in config.get("architectures", [])
+                for arch in outer_architectures
             ):
                 warnings.warn(
                     "`experimental=True` was set, but either `config.json` doesn't have the `architectures` key meaning that the model architecture cannot be inferred, or rather that it's neither `...ForCausalLM` nor `...ForConditionalGeneration`, meaning that the KV Cache estimation might not apply. If that's the case, then set `experimental=False` to suppress this warning."

--- a/src/hf_mem/run.py
+++ b/src/hf_mem/run.py
@@ -10,12 +10,13 @@ from uuid import uuid4
 import httpx
 
 from hf_mem._fetch import get_json_file
-from hf_mem._types import KvCache
+from hf_mem._types import KvCache, WarmupPeak
 from hf_mem._version import __version__
 from hf_mem.gguf.fetch import fetch_gguf_with_semaphore
 from hf_mem.gguf.metadata import GGUFDtype, GGUFMetadata, merge_shards
 from hf_mem.safetensors.fetch import fetch_modules_and_dense_metadata, fetch_safetensors_metadata
 from hf_mem.safetensors.kv_cache import compute_safetensors_kv_cache_size, resolve_kv_cache_dtype
+from hf_mem.safetensors.warmup_peak import compute_safetensors_warmup_peak
 from hf_mem.safetensors.metadata import (
     MoEMetadata,
     SafetensorsMetadata,
@@ -42,7 +43,10 @@ class Result:
     # `kv_cache` mirrors the shape of `memory` but for the KV cache estimation; None when
     # experimental=False or the model architecture does not support KV cache estimation
     kv_cache: Union[int, Dict[str, int], None]
-    # `total_memory` is memory + kv_cache for single-file results; None for multi-GGUF
+    # `warmup_peak` is the activation peak during a vLLM/TEI-style warmup forward pass.
+    # Only computed for Safetensors when --max-num-batched-tokens is set; None otherwise.
+    warmup_peak: int | None
+    # `total_memory` is memory + kv_cache + warmup_peak for single-file results; None for multi-GGUF
     total_memory: int | None
 
     # NOTE: When True, to_json() enriches `memory` and `kv_cache` with per-component /
@@ -53,6 +57,7 @@ class Result:
     gguf_files: Dict[str, GGUFMetadata] | None = field(default=None, repr=False)
     kv_cache_metadata: KvCache | None = field(default=None, repr=False)
     moe_metadata: MoEMetadata | None = field(default=None, repr=False)
+    warmup_peak_metadata: WarmupPeak | None = field(default=None, repr=False)
 
     def _component_to_json(self, component: Any) -> Dict[str, Any]:
         out = {
@@ -74,6 +79,8 @@ class Result:
         if not self.details:
             out["memory"] = self.memory
             out["kv_cache"] = self.kv_cache
+            if self.warmup_peak is not None:
+                out["warmup_peak"] = self.warmup_peak
             out["total_memory"] = self.total_memory
             if self.moe_metadata is not None:
                 out["moe"] = {
@@ -113,6 +120,13 @@ class Result:
                 if self.kv_cache_metadata is not None
                 else None
             )
+            if self.warmup_peak_metadata is not None:
+                out["warmup_peak"] = {
+                    "bytes": self.warmup_peak_metadata.peak_bytes,
+                    "dtype": self.warmup_peak_metadata.activation_dtype,
+                    "max_num_batched_tokens": self.warmup_peak_metadata.max_num_batched_tokens,
+                    "max_num_seqs": self.warmup_peak_metadata.max_num_seqs,
+                }
             if self.moe_metadata is not None:
                 out["moe"] = {
                     "base_model": self._component_to_json(self.moe_metadata.base_model),
@@ -217,7 +231,13 @@ async def arun(
     kv_cache_dtype: str = "auto",
     gguf_file: str | None = None,
     details: bool = False,
+    max_num_batched_tokens: int | None = None,
 ) -> Result:
+    if max_num_batched_tokens is not None and max_num_batched_tokens <= 0:
+        raise RuntimeError(
+            f"--max-num-batched-tokens must be a positive integer, got {max_num_batched_tokens}."
+        )
+
     headers: Dict[str, str] = {
         "User-Agent": f"hf-mem/{__version__}; id={uuid4()}; model_id={model_id}; revision={revision}"
     }
@@ -335,6 +355,7 @@ async def arun(
                 filename=single_filename,
                 memory=gguf_meta.bytes_count,
                 kv_cache=kv_bytes,
+                warmup_peak=None,
                 total_memory=gguf_meta.bytes_count + (kv_bytes or 0),
                 details=details,
                 gguf_files=gguf_files_dict,
@@ -359,6 +380,7 @@ async def arun(
                 filename=None,
                 memory=memory_dict,
                 kv_cache=kv_dict,
+                warmup_peak=None,
                 total_memory=None,
                 details=details,
                 gguf_files=gguf_files_dict,
@@ -485,90 +507,113 @@ async def arun(
 
     kv_cache_cls: KvCache | None = None
     moe_metadata: MoEMetadata | None = None
-    if experimental and "config.json" in file_paths:
+    warmup_peak_cls: WarmupPeak | None = None
+
+    need_config = (experimental or max_num_batched_tokens is not None) and "config.json" in file_paths
+    if need_config:
         url = f"https://huggingface.co/{model_id}/resolve/{revision}/config.json"
         config: Dict[str, Any] = await get_json_file(client, url, headers)
 
-        if not any(
-            arch.__contains__("ForCausalLM") or arch.__contains__("ForConditionalGeneration")
-            for arch in config.get("architectures", [])
+        # NOTE: For ...ForConditionalGeneration with a text_config, prefer the text config —
+        # same logic as before, just lifted out of the KV-cache-only branch.
+        if (
+            any(arch.__contains__("ForConditionalGeneration") for arch in config.get("architectures", []))
+            and "text_config" in config
         ):
             warnings.warn(
-                "`experimental=True` was set, but either `config.json` doesn't have the `architectures` key meaning that the model architecture cannot be inferred, or rather that it's neither `...ForCausalLM` nor `...ForConditionalGeneration`, meaning that the KV Cache estimation might not apply. If that's the case, then set `experimental=False` to suppress this warning."
+                f"Given that `model_id={model_id}` is a `...ForConditionalGeneration` model, then the configuration from `config.json` will be retrieved from the key `text_config` instead."
             )
-        else:
-            if (
-                any(arch.__contains__("ForConditionalGeneration") for arch in config["architectures"])
-                and "text_config" in config
+            text_config = config["text_config"]
+
+            if referenced_model := text_config.get("_name_or_path"):
+                referenced_url = f"https://huggingface.co/{referenced_model}/resolve/{revision}/config.json"
+                warnings.warn(
+                    f"The `text_config` contains `_name_or_path={referenced_model}`, so fetching the config from `{referenced_model}` to retrieve the required fields for KV cache estimation."
+                )
+                referenced_config = await get_json_file(client, referenced_url, headers)
+                referenced_config.update(text_config)
+                text_config = referenced_config
+
+            for key in ("dtype", "torch_dtype", "quantization_config"):
+                if key in config and key not in text_config:
+                    text_config[key] = config[key]
+
+            config = text_config
+
+        if experimental:
+            if not any(
+                arch.__contains__("ForCausalLM") or arch.__contains__("ForConditionalGeneration")
+                for arch in config.get("architectures", [])
             ):
                 warnings.warn(
-                    f"Given that `model_id={model_id}` is a `...ForConditionalGeneration` model, then the configuration from `config.json` will be retrieved from the key `text_config` instead."
-                )
-                text_config = config["text_config"]
-
-                if referenced_model := text_config.get("_name_or_path"):
-                    referenced_url = f"https://huggingface.co/{referenced_model}/resolve/{revision}/config.json"
-                    warnings.warn(
-                        f"The `text_config` contains `_name_or_path={referenced_model}`, so fetching the config from `{referenced_model}` to retrieve the required fields for KV cache estimation."
-                    )
-                    referenced_config = await get_json_file(client, referenced_url, headers)
-                    referenced_config.update(text_config)
-                    text_config = referenced_config
-
-                for key in ("dtype", "torch_dtype", "quantization_config"):
-                    if key in config and key not in text_config:
-                        text_config[key] = config[key]
-
-                config = text_config
-
-            moe_metadata = parse_moe_metadata(raw_metadata=raw_metadata, config=config)
-
-            if max_model_len is None:
-                max_model_len = config.get(
-                    "max_position_embeddings",
-                    config.get("n_positions", config.get("max_seq_len", max_model_len)),
-                )
-
-            if max_model_len is None:
-                warnings.warn(
-                    "Either `max_model_len` was not set, is not available in `config.json` under any of `max_position_embeddings`, `n_positions`, or `max_seq_len` (in that order of priority), or both; so the memory required to fit the context length cannot be estimated."
-                )
-            elif not all(k in config for k in {"hidden_size", "num_hidden_layers", "num_attention_heads"}):
-                warnings.warn(
-                    f"`config.json` doesn't contain all the required keys `hidden_size`, `num_hidden_layers`, and `num_attention_heads`, but only {list(config.keys())}."
+                    "`experimental=True` was set, but either `config.json` doesn't have the `architectures` key meaning that the model architecture cannot be inferred, or rather that it's neither `...ForCausalLM` nor `...ForConditionalGeneration`, meaning that the KV Cache estimation might not apply. If that's the case, then set `experimental=False` to suppress this warning."
                 )
             else:
-                cache_dtype = resolve_kv_cache_dtype(
-                    config=config,
-                    kv_cache_dtype=kv_cache_dtype,
-                    metadata=metadata,
-                    model_id=model_id,
-                )
-                kv_cache_cls = KvCache(
-                    max_model_len=max_model_len,
-                    cache_size=compute_safetensors_kv_cache_size(
+                moe_metadata = parse_moe_metadata(raw_metadata=raw_metadata, config=config)
+
+                if max_model_len is None:
+                    max_model_len = config.get(
+                        "max_position_embeddings",
+                        config.get("n_positions", config.get("max_seq_len", max_model_len)),
+                    )
+
+                if max_model_len is None:
+                    warnings.warn(
+                        "Either `max_model_len` was not set, is not available in `config.json` under any of `max_position_embeddings`, `n_positions`, or `max_seq_len` (in that order of priority), or both; so the memory required to fit the context length cannot be estimated."
+                    )
+                elif not all(k in config for k in {"hidden_size", "num_hidden_layers", "num_attention_heads"}):
+                    warnings.warn(
+                        f"`config.json` doesn't contain all the required keys `hidden_size`, `num_hidden_layers`, and `num_attention_heads`, but only {list(config.keys())}."
+                    )
+                else:
+                    cache_dtype = resolve_kv_cache_dtype(
                         config=config,
-                        cache_dtype=cache_dtype,
+                        kv_cache_dtype=kv_cache_dtype,
+                        metadata=metadata,
+                        model_id=model_id,
+                    )
+                    kv_cache_cls = KvCache(
                         max_model_len=max_model_len,
+                        cache_size=compute_safetensors_kv_cache_size(
+                            config=config,
+                            cache_dtype=cache_dtype,
+                            max_model_len=max_model_len,
+                            batch_size=batch_size,
+                        ),
                         batch_size=batch_size,
-                    ),
-                    batch_size=batch_size,
-                    cache_dtype=cache_dtype,
-                )
+                        cache_dtype=cache_dtype,
+                    )
+
+        if max_num_batched_tokens is not None:
+            warmup_peak_cls = compute_safetensors_warmup_peak(
+                config=config,
+                max_num_batched_tokens=max_num_batched_tokens,
+                batch_size=batch_size,
+                file_paths=file_paths,
+                model_id=model_id,
+            )
+    elif max_num_batched_tokens is not None and "config.json" not in file_paths:
+        warnings.warn(
+            f"`--max-num-batched-tokens` is set but `config.json` is not present for "
+            f"`--model-id={model_id}`; skipping warmup peak estimate."
+        )
 
     await client.aclose()
     kv_bytes = kv_cache_cls.cache_size if kv_cache_cls is not None else None
+    warmup_bytes = warmup_peak_cls.peak_bytes if warmup_peak_cls is not None else None
     return Result(
         model_id=model_id,
         revision=revision,
         filename=None,
         memory=metadata.bytes_count,
         kv_cache=kv_bytes,
-        total_memory=metadata.bytes_count + (kv_bytes or 0),
+        warmup_peak=warmup_bytes,
+        total_memory=metadata.bytes_count + (kv_bytes or 0) + (warmup_bytes or 0),
         details=details,
         safetensors=metadata,
         kv_cache_metadata=kv_cache_cls,
         moe_metadata=moe_metadata,
+        warmup_peak_metadata=warmup_peak_cls,
     )
 
 
@@ -582,6 +627,7 @@ def run(
     kv_cache_dtype: str = "auto",
     gguf_file: str | None = None,
     details: bool = False,
+    max_num_batched_tokens: int | None = None,
 ) -> Result:
     try:
         asyncio.get_running_loop()
@@ -597,6 +643,7 @@ def run(
                 kv_cache_dtype=kv_cache_dtype,
                 gguf_file=gguf_file,
                 details=details,
+                max_num_batched_tokens=max_num_batched_tokens,
             )
         )
 

--- a/src/hf_mem/run.py
+++ b/src/hf_mem/run.py
@@ -46,7 +46,9 @@ class Result:
     # `warmup_peak` is the activation peak during a vLLM/TEI-style warmup forward pass.
     # Only computed for Safetensors when --max-num-batched-tokens is set; None otherwise.
     warmup_peak: int | None
-    # `total_memory` is memory + kv_cache + warmup_peak for single-file results; None for multi-GGUF
+    # `total_memory` is memory + kv_cache + warmup_peak for the Safetensors single-file path;
+    # memory + kv_cache for the GGUF single-file path (warmup_peak is not computed for GGUF);
+    # None for multi-GGUF
     total_memory: int | None
 
     # NOTE: When True, to_json() enriches `memory` and `kv_cache` with per-component /
@@ -528,7 +530,7 @@ async def arun(
             if referenced_model := text_config.get("_name_or_path"):
                 referenced_url = f"https://huggingface.co/{referenced_model}/resolve/{revision}/config.json"
                 warnings.warn(
-                    f"The `text_config` contains `_name_or_path={referenced_model}`, so fetching the config from `{referenced_model}` to retrieve the required fields for KV cache estimation."
+                    f"The `text_config` contains `_name_or_path={referenced_model}`, so fetching the config from `{referenced_model}` to retrieve the required fields for KV cache / warmup peak estimation."
                 )
                 referenced_config = await get_json_file(client, referenced_url, headers)
                 referenced_config.update(text_config)

--- a/src/hf_mem/run.py
+++ b/src/hf_mem/run.py
@@ -16,13 +16,13 @@ from hf_mem.gguf.fetch import fetch_gguf_with_semaphore
 from hf_mem.gguf.metadata import GGUFDtype, GGUFMetadata, merge_shards
 from hf_mem.safetensors.fetch import fetch_modules_and_dense_metadata, fetch_safetensors_metadata
 from hf_mem.safetensors.kv_cache import compute_safetensors_kv_cache_size, resolve_kv_cache_dtype
-from hf_mem.safetensors.warmup_peak import compute_safetensors_warmup_peak
 from hf_mem.safetensors.metadata import (
     MoEMetadata,
     SafetensorsMetadata,
     parse_moe_metadata,
     parse_safetensors_metadata,
 )
+from hf_mem.safetensors.warmup_peak import compute_safetensors_warmup_peak
 
 MAX_CONCURRENCY = int(os.getenv("MAX_WORKERS", min(32, (os.cpu_count() or 1) + 4)))
 

--- a/src/hf_mem/safetensors/print.py
+++ b/src/hf_mem/safetensors/print.py
@@ -48,7 +48,7 @@ def print_safetensors_report(
         centered_rows.append(f"w/ max-model-len={kv_cache.max_model_len}, batch-size={kv_cache.batch_size}")
     if warmup_peak:
         centered_rows.append(
-            f"w/ max-num-batched-tokens={warmup_peak.max_num_batched_tokens}, batch-size={warmup_peak.max_num_seqs}"
+            f"w/ max-num-batched-tokens={warmup_peak.max_num_batched_tokens}, max-num-seqs={warmup_peak.max_num_seqs}"
         )
     for name, nested_metadata in metadata.components.items():
         if len(metadata.components) > 1:
@@ -147,7 +147,7 @@ def print_safetensors_report(
         )
     if warmup_peak:
         _print_centered(
-            f"w/ max-num-batched-tokens={warmup_peak.max_num_batched_tokens}, batch-size={warmup_peak.max_num_seqs}",
+            f"w/ max-num-batched-tokens={warmup_peak.max_num_batched_tokens}, max-num-seqs={warmup_peak.max_num_seqs}",
             current_len,
         )
     _print_divider(data_col_width + 1, "top")

--- a/src/hf_mem/safetensors/print.py
+++ b/src/hf_mem/safetensors/print.py
@@ -80,12 +80,13 @@ def print_safetensors_report(
         ]
         centered_rows.extend(moe_rows)
 
-    data_rows = []
     extras = []
     if kv_cache:
         extras.append("KV CACHE")
     if warmup_peak:
         extras.append("WARMUP PEAK")
+
+    data_rows = []
     if extras:
         data_rows.append(
             f"{_bytes_to_gib(combined_total):.2f} GiB ({_format_short_number(metadata.param_count)} PARAMS + {' + '.join(extras)})"
@@ -118,7 +119,9 @@ def print_safetensors_report(
     if kv_cache:
         data_rows.append(f"{_bytes_to_gib(kv_cache.cache_size):.2f} / {_bytes_to_gib(combined_total):.2f} GiB")
     if warmup_peak:
-        data_rows.append(f"{_bytes_to_gib(warmup_peak.peak_bytes):.2f} / {_bytes_to_gib(combined_total):.2f} GiB")
+        data_rows.append(
+            f"{_bytes_to_gib(warmup_peak.peak_bytes):.2f} / {_bytes_to_gib(combined_total):.2f} GiB"
+        )
 
     max_centered_len = max(len(r) for r in centered_rows)
     max_data_len = max(len(r) for r in data_rows)
@@ -149,15 +152,10 @@ def print_safetensors_report(
         )
     _print_divider(data_col_width + 1, "top")
 
-    if kv_cache or warmup_peak:
-        suffix_parts = []
-        if kv_cache:
-            suffix_parts.append("KV CACHE")
-        if warmup_peak:
-            suffix_parts.append("WARMUP PEAK")
+    if extras:
         total_text = (
             f"{_bytes_to_gib(combined_total):.2f} GiB "
-            f"({_format_short_number(metadata.param_count)} PARAMS + {' + '.join(suffix_parts)})"
+            f"({_format_short_number(metadata.param_count)} PARAMS + {' + '.join(extras)})"
         )
         total_bar = _make_bar(combined_total, combined_total, data_col_width)
         _print_row("TOTAL MEMORY", total_text, data_col_width)

--- a/src/hf_mem/safetensors/print.py
+++ b/src/hf_mem/safetensors/print.py
@@ -46,7 +46,7 @@ def print_safetensors_report(
     ]
     if kv_cache:
         centered_rows.append(f"w/ max-model-len={kv_cache.max_model_len}, batch-size={kv_cache.batch_size}")
-    elif warmup_peak:
+    if warmup_peak:
         centered_rows.append(
             f"w/ max-num-batched-tokens={warmup_peak.max_num_batched_tokens}, batch-size={warmup_peak.max_num_seqs}"
         )
@@ -142,7 +142,7 @@ def print_safetensors_report(
             f"w/ max-model-len={kv_cache.max_model_len}, batch-size={kv_cache.batch_size}",
             current_len,
         )
-    elif warmup_peak:
+    if warmup_peak:
         _print_centered(
             f"w/ max-num-batched-tokens={warmup_peak.max_num_batched_tokens}, batch-size={warmup_peak.max_num_seqs}",
             current_len,

--- a/src/hf_mem/safetensors/print.py
+++ b/src/hf_mem/safetensors/print.py
@@ -12,7 +12,7 @@ from hf_mem._print import (
     _print_header,
     _print_row,
 )
-from hf_mem._types import KvCache
+from hf_mem._types import KvCache, WarmupPeak
 from hf_mem._version import __version__
 from hf_mem.safetensors.metadata import MoEMetadata, SafetensorsMetadata
 
@@ -31,8 +31,13 @@ def print_safetensors_report(
     metadata: SafetensorsMetadata,
     kv_cache: KvCache | None = None,
     moe: MoEMetadata | None = None,
+    warmup_peak: WarmupPeak | None = None,
 ) -> None:
-    combined_total = metadata.bytes_count + kv_cache.cache_size if kv_cache else metadata.bytes_count
+    combined_total = (
+        metadata.bytes_count
+        + (kv_cache.cache_size if kv_cache else 0)
+        + (warmup_peak.peak_bytes if warmup_peak else 0)
+    )
     model_total = metadata.bytes_count
 
     centered_rows = [
@@ -41,18 +46,26 @@ def print_safetensors_report(
     ]
     if kv_cache:
         centered_rows.append(f"w/ max-model-len={kv_cache.max_model_len}, batch-size={kv_cache.batch_size}")
+    elif warmup_peak:
+        centered_rows.append(
+            f"w/ max-num-batched-tokens={warmup_peak.max_num_batched_tokens}, batch-size={warmup_peak.max_num_seqs}"
+        )
     for name, nested_metadata in metadata.components.items():
         if len(metadata.components) > 1:
             centered_rows.append(
                 f"{name.upper()} ({_format_short_number(nested_metadata.param_count)} PARAMS, {_bytes_to_gib(nested_metadata.bytes_count):.2f} GiB)"
             )
-        elif kv_cache:
+        elif kv_cache or warmup_peak:
             centered_rows.append(
                 f"MODEL ({_format_short_number(nested_metadata.param_count)} PARAMS, {_bytes_to_gib(nested_metadata.bytes_count):.2f} GiB)"
             )
     if kv_cache:
         centered_rows.append(
             f"KV CACHE ({kv_cache.max_model_len * kv_cache.batch_size} TOKENS, {_bytes_to_gib(kv_cache.cache_size):.2f} GiB)"
+        )
+    if warmup_peak:
+        centered_rows.append(
+            f"WARMUP PEAK ({warmup_peak.max_num_batched_tokens} TOKENS, {_bytes_to_gib(warmup_peak.peak_bytes):.2f} GiB)"
         )
     if moe:
         moe_rows = [
@@ -68,9 +81,14 @@ def print_safetensors_report(
         centered_rows.extend(moe_rows)
 
     data_rows = []
+    extras = []
     if kv_cache:
+        extras.append("KV CACHE")
+    if warmup_peak:
+        extras.append("WARMUP PEAK")
+    if extras:
         data_rows.append(
-            f"{_bytes_to_gib(combined_total):.2f} GiB ({_format_short_number(metadata.param_count)} PARAMS + KV CACHE)"
+            f"{_bytes_to_gib(combined_total):.2f} GiB ({_format_short_number(metadata.param_count)} PARAMS + {' + '.join(extras)})"
         )
     else:
         data_rows.append(
@@ -99,6 +117,8 @@ def print_safetensors_report(
             )
     if kv_cache:
         data_rows.append(f"{_bytes_to_gib(kv_cache.cache_size):.2f} / {_bytes_to_gib(combined_total):.2f} GiB")
+    if warmup_peak:
+        data_rows.append(f"{_bytes_to_gib(warmup_peak.peak_bytes):.2f} / {_bytes_to_gib(combined_total):.2f} GiB")
 
     max_centered_len = max(len(r) for r in centered_rows)
     max_data_len = max(len(r) for r in data_rows)
@@ -122,12 +142,22 @@ def print_safetensors_report(
             f"w/ max-model-len={kv_cache.max_model_len}, batch-size={kv_cache.batch_size}",
             current_len,
         )
+    elif warmup_peak:
+        _print_centered(
+            f"w/ max-num-batched-tokens={warmup_peak.max_num_batched_tokens}, batch-size={warmup_peak.max_num_seqs}",
+            current_len,
+        )
     _print_divider(data_col_width + 1, "top")
 
-    if kv_cache:
+    if kv_cache or warmup_peak:
+        suffix_parts = []
+        if kv_cache:
+            suffix_parts.append("KV CACHE")
+        if warmup_peak:
+            suffix_parts.append("WARMUP PEAK")
         total_text = (
             f"{_bytes_to_gib(combined_total):.2f} GiB "
-            f"({_format_short_number(metadata.param_count)} PARAMS + KV CACHE)"
+            f"({_format_short_number(metadata.param_count)} PARAMS + {' + '.join(suffix_parts)})"
         )
         total_bar = _make_bar(combined_total, combined_total, data_col_width)
         _print_row("TOTAL MEMORY", total_text, data_col_width)
@@ -213,7 +243,7 @@ def print_safetensors_report(
                 current_len,
             )
             _print_divider(data_col_width + 1, "top")
-        elif kv_cache:
+        elif kv_cache or warmup_peak:
             _print_divider(data_col_width + 1, "top-continue")
             _print_centered(
                 f"MODEL ({_format_short_number(value.param_count)} PARAMS, {_bytes_to_gib(value.bytes_count):.2f} GiB)",
@@ -271,6 +301,29 @@ def print_safetensors_report(
         _print_row(
             f"{kv_cache.max_model_len * kv_cache.batch_size} TOKENS",
             kv_bar,
+            data_col_width,
+        )
+
+    if warmup_peak:
+        _print_divider(data_col_width + 1, "top-continue")
+        _print_centered(
+            f"WARMUP PEAK ({warmup_peak.max_num_batched_tokens} TOKENS, {_bytes_to_gib(warmup_peak.peak_bytes):.2f} GiB)",
+            current_len,
+        )
+        _print_divider(data_col_width + 1, "top")
+
+        wp_dtype_label = (warmup_peak.activation_dtype or "?").upper()
+        wp_text = f"{_bytes_to_gib(warmup_peak.peak_bytes):.2f} / {_bytes_to_gib(combined_total):.2f} GiB"
+        _print_row(
+            wp_dtype_label + " " * max(0, max_length - len(wp_dtype_label)),
+            wp_text,
+            data_col_width,
+        )
+
+        wp_bar = _make_bar(warmup_peak.peak_bytes, combined_total, data_col_width)
+        _print_row(
+            f"{warmup_peak.max_num_batched_tokens} TOKENS",
+            wp_bar,
             data_col_width,
         )
 

--- a/src/hf_mem/safetensors/warmup_peak.py
+++ b/src/hf_mem/safetensors/warmup_peak.py
@@ -14,13 +14,9 @@ ModelClass = Literal[
     "base_encoder",
 ]
 
-# Architecture-suffix → ModelClass. Matching is via `__contains__` (substring),
-# mirroring how run.py already detects ForCausalLM / ForConditionalGeneration.
+# NOTE: Architecture-suffix → ModelClass; matched via substring, mirroring how
+# run.py already detects ForCausalLM / ForConditionalGeneration
 _ARCH_SUFFIX_MAP: list[tuple[str, ModelClass]] = [
-    # Order matters: more specific suffixes must come before less specific ones
-    # so that e.g. `BertForSequenceClassification` matches before `BertModel` would
-    # (it never does here since we only match the listed suffixes, but keep the
-    # discipline for future additions).
     ("ForCausalLM", "causal_lm"),
     ("ForConditionalGeneration", "conditional_gen"),
     ("ForMaskedLM", "masked_lm"),
@@ -31,26 +27,22 @@ _ARCH_SUFFIX_MAP: list[tuple[str, ModelClass]] = [
     ("ForTokenClassification", "token_classification"),
 ]
 
+# NOTE: Safetensors dtypes that are quantized weight storage formats; for the warmup
+# forward pass the activations are dequantized to a higher-precision compute dtype
+_QUANTIZED_SAFETENSORS_DTYPES = {"F8_E4M3", "F8_E5M2", "F8_E8M0", "I8"}
+
 
 def classify_architecture(architectures: List[str], file_paths: List[str]) -> ModelClass | None:
-    """Map HF `config.architectures` to a ModelClass used by the warmup peak formula.
-
-    Returns None when no known suffix is found AND the repo is not a Sentence Transformers
-    model — in that case the caller should warn and skip the warmup peak estimate.
-    """
     for arch in architectures or []:
         for suffix, model_class in _ARCH_SUFFIX_MAP:
             if suffix in arch:
                 return model_class
 
-    # Sentence Transformers and bare `…Model` (e.g. BertModel used as an encoder)
-    # both fall under "base_encoder". Sentence Transformers is identifiable via
-    # the presence of `config_sentence_transformers.json` in the repo.
+    # NOTE: Sentence Transformers repos are identified by `config_sentence_transformers.json`
     if "config_sentence_transformers.json" in file_paths:
         return "base_encoder"
 
-    # Bare `…Model` architectures (e.g. BertModel, RobertaModel, XLMRobertaModel) —
-    # only when the architecture string ends in "Model" without a head suffix.
+    # NOTE: Bare `…Model` architectures (e.g. BertModel) are encoder-only
     for arch in architectures or []:
         if arch.endswith("Model") and "ForCausalLM" not in arch and "ForConditionalGeneration" not in arch:
             return "base_encoder"
@@ -59,43 +51,33 @@ def classify_architecture(architectures: List[str], file_paths: List[str]) -> Mo
 
 
 def resolve_activation_dtype(config: Dict[str, Any]) -> str:
-    """Resolve the activation (compute) dtype for the warmup forward pass.
-
-    Returns a Safetensors dtype string (e.g. "BF16", "F16", "F32"). Never returns
-    None — falls back to F32 (HuggingFace's default) when no dtype info is found.
-
-    Resolution order:
-      1. torch_dtype / dtype, if it is a non-quantized dtype.
-      2. If torch_dtype / dtype resolves to a quantized dtype (float8_*), assume bf16
-         as the dequantized compute dtype.
-      3. If quantization_config is present but no torch_dtype/dtype, assume bf16.
-      4. Otherwise F32 — HuggingFace Transformers' default compute dtype when
-         torch_dtype / dtype is absent (common for older BERT-family models).
-    """
-    _QUANTIZED_TORCH_DTYPES = {"float8_e4m3", "float8_e4m3fn", "float8_e5m2", "int8"}
-
-    raw = config.get("torch_dtype") or config.get("dtype")
-    if isinstance(raw, str):
-        normalized = raw.replace("torch.", "")
-        if normalized in _QUANTIZED_TORCH_DTYPES:
-            return "BF16"  # dequantized compute dtype
-        return torch_dtype_to_safetensors_dtype(normalized)
+    # NOTE: Falls back to F32 (HuggingFace Transformers' default when `torch_dtype` / `dtype`
+    # is absent) for older BERT-family / Sentence Transformers models. For quantized weights,
+    # assume BF16 as the dequantized compute dtype.
+    if raw := (config.get("torch_dtype") or config.get("dtype")):
+        if isinstance(raw, str):
+            resolved = torch_dtype_to_safetensors_dtype(raw)
+            if resolved in _QUANTIZED_SAFETENSORS_DTYPES:
+                return "BF16"
+            return resolved
 
     if "quantization_config" in config:
         return "BF16"
 
-    # HuggingFace Transformers' default when torch_dtype / dtype absent is float32.
-    # Many older BERT-family / Sentence Transformers models don't set the field at all.
     return "F32"
 
 
-def _resolve_num_labels(config: Dict[str, Any]) -> int | None:
+def _resolve_num_labels(config: Dict[str, Any], model_id: str) -> int | None:
     value = config.get("num_labels")
     if isinstance(value, int) and value > 0:
         return value
     id2label = config.get("id2label")
     if isinstance(id2label, dict) and len(id2label) > 0:
         return len(id2label)
+    warnings.warn(
+        f"Warmup peak estimate skipped for `--model-id={model_id}`: classifier "
+        f"architecture without `num_labels` or `id2label` in `config.json`."
+    )
     return None
 
 
@@ -117,17 +99,10 @@ def compute_safetensors_warmup_peak(
     file_paths: List[str],
     model_id: str,
 ) -> WarmupPeak | None:
-    """Approximate the peak activation memory during one warmup forward pass.
-
-    Models what PyTorch's caching allocator holds: a persistent residual stream
-    of (T × H × d_act), plus the largest transient at any one point in the forward.
-
-    Returns None (with a warning) on any of:
-      - architecture not in the supported taxonomy
-      - required config keys missing
-      - activation dtype unresolvable
-      - classifier architecture without num_labels / id2label
-    """
+    # NOTE: Models PyTorch's caching-allocator behavior: a persistent residual stream
+    # of (T × H × d_act), plus the largest transient (attention / FFN / head) at any
+    # one point in the forward. Returns None (with a warning) when the architecture
+    # is unsupported or required config keys are missing.
     architectures = config.get("architectures", []) or []
     model_class = classify_architecture(architectures, file_paths)
     if model_class is None:
@@ -182,7 +157,8 @@ def compute_safetensors_warmup_peak(
     attn_transient = T * (num_attention_heads + 2 * num_key_value_heads) * head_dim * d
     ffn_transient = ffn_multiplier * T * ffn_width * d
 
-    # Terminal "head" spike — model-class-dependent.
+    # NOTE: Terminal head spike — applied to every token for masked LM / token
+    # classification, only the last token of each sequence (S) for the rest.
     lm_head_spike: int
     match model_class:
         case "causal_lm" | "conditional_gen":
@@ -194,23 +170,15 @@ def compute_safetensors_warmup_peak(
             vocab_size = _resolve_vocab_size(config, model_id, "masked LM")
             if vocab_size is None:
                 return None
-            lm_head_spike = T * vocab_size * d  # LM head applied to every token
+            lm_head_spike = T * vocab_size * d
         case "seq_classification":
-            num_labels = _resolve_num_labels(config)
+            num_labels = _resolve_num_labels(config, model_id)
             if num_labels is None:
-                warnings.warn(
-                    f"Warmup peak estimate skipped for `--model-id={model_id}`: classifier "
-                    f"architecture without `num_labels` or `id2label` in `config.json`."
-                )
                 return None
             lm_head_spike = S * num_labels * d
         case "token_classification":
-            num_labels = _resolve_num_labels(config)
+            num_labels = _resolve_num_labels(config, model_id)
             if num_labels is None:
-                warnings.warn(
-                    f"Warmup peak estimate skipped for `--model-id={model_id}`: classifier "
-                    f"architecture without `num_labels` or `id2label` in `config.json`."
-                )
                 return None
             lm_head_spike = T * num_labels * d
         case "base_encoder":

--- a/src/hf_mem/safetensors/warmup_peak.py
+++ b/src/hf_mem/safetensors/warmup_peak.py
@@ -11,6 +11,7 @@ ModelClass = Literal[
     "masked_lm",
     "seq_classification",
     "token_classification",
+    "question_answering",
     "base_encoder",
 ]
 
@@ -22,8 +23,10 @@ _ARCH_SUFFIX_MAP: list[tuple[str, ModelClass]] = [
     ("ForMaskedLM", "masked_lm"),
     ("ForPreTraining", "masked_lm"),
     ("ForSequenceClassification", "seq_classification"),
-    ("ForQuestionAnswering", "seq_classification"),
     ("ForMultipleChoice", "seq_classification"),
+    # NOTE: QA heads produce per-token start/end logits (T × 2), not a pooled
+    # (S × num_labels) spike; structurally fixed at 2 outputs (start, end)
+    ("ForQuestionAnswering", "question_answering"),
     ("ForTokenClassification", "token_classification"),
 ]
 
@@ -181,6 +184,8 @@ def compute_safetensors_warmup_peak(
             if num_labels is None:
                 return None
             lm_head_spike = T * num_labels * d
+        case "question_answering":
+            lm_head_spike = T * 2 * d
         case "base_encoder":
             lm_head_spike = S * hidden_size * d
 

--- a/src/hf_mem/safetensors/warmup_peak.py
+++ b/src/hf_mem/safetensors/warmup_peak.py
@@ -1,6 +1,7 @@
 import warnings
 from typing import Any, Dict, List, Literal
 
+from hf_mem._types import WarmupPeak
 from hf_mem.safetensors.types import get_safetensors_dtype_bytes, torch_dtype_to_safetensors_dtype
 
 ModelClass = Literal[
@@ -107,9 +108,6 @@ def _resolve_num_labels(config: Dict[str, Any]) -> int | None:
     if isinstance(id2label, dict) and len(id2label) > 0:
         return len(id2label)
     return None
-
-
-from hf_mem._types import WarmupPeak
 
 
 def compute_safetensors_warmup_peak(

--- a/src/hf_mem/safetensors/warmup_peak.py
+++ b/src/hf_mem/safetensors/warmup_peak.py
@@ -2,6 +2,7 @@ import warnings
 from typing import Any, Dict, List, Literal
 
 from hf_mem._types import WarmupPeak
+from hf_mem.safetensors.metadata import _get_config_int
 from hf_mem.safetensors.types import get_safetensors_dtype_bytes, torch_dtype_to_safetensors_dtype
 
 ModelClass = Literal[
@@ -88,18 +89,6 @@ def resolve_activation_dtype(config: Dict[str, Any]) -> str:
     return "F32"
 
 
-def _activation_dtype_bytes(dtype: str) -> int:
-    return get_safetensors_dtype_bytes(dtype)
-
-
-def _resolve_intermediate_size(config: Dict[str, Any]) -> int | None:
-    for key in ("intermediate_size", "ffn_dim", "n_inner"):
-        value = config.get(key)
-        if isinstance(value, int) and value > 0:
-            return value
-    return None
-
-
 def _resolve_num_labels(config: Dict[str, Any]) -> int | None:
     value = config.get("num_labels")
     if isinstance(value, int) and value > 0:
@@ -107,6 +96,17 @@ def _resolve_num_labels(config: Dict[str, Any]) -> int | None:
     id2label = config.get("id2label")
     if isinstance(id2label, dict) and len(id2label) > 0:
         return len(id2label)
+    return None
+
+
+def _resolve_vocab_size(config: Dict[str, Any], model_id: str, label: str) -> int | None:
+    vocab_size = config.get("vocab_size")
+    if isinstance(vocab_size, int) and vocab_size > 0:
+        return vocab_size
+    warnings.warn(
+        f"Warmup peak estimate skipped for `--model-id={model_id}`: "
+        f"`config.json` missing `vocab_size` for a {label}."
+    )
     return None
 
 
@@ -149,7 +149,7 @@ def compute_safetensors_warmup_peak(
         )
         return None
 
-    intermediate_size = _resolve_intermediate_size(config)
+    intermediate_size = _get_config_int(config, "intermediate_size", "ffn_dim", "n_inner")
     if intermediate_size is None:
         warnings.warn(
             f"Warmup peak estimate skipped for `--model-id={model_id}`: could not resolve "
@@ -163,18 +163,18 @@ def compute_safetensors_warmup_peak(
     num_key_value_heads: int = config.get("num_key_value_heads", num_attention_heads)
     head_dim: int = config.get("head_dim", hidden_size // num_attention_heads)
 
-    # MoE adjustment: when num_experts_per_tok is present, the FFN transient is
-    # the per-token activation across active experts only.
-    num_experts_per_tok = config.get("num_experts_per_tok") or config.get("num_experts_per_token") or config.get("top_k")
+    # MoE adjustment: when num_experts_per_tok > 1, the FFN transient grows linearly
+    # with the active expert count.
+    num_experts_per_tok = _get_config_int(config, "num_experts_per_tok", "num_experts_per_token", "top_k")
     moe_intermediate_size = config.get("moe_intermediate_size")
-    if isinstance(num_experts_per_tok, int) and num_experts_per_tok > 0:
+    if num_experts_per_tok is not None:
         ffn_width = moe_intermediate_size if isinstance(moe_intermediate_size, int) else intermediate_size
         ffn_multiplier = 2 * num_experts_per_tok
     else:
         ffn_width = intermediate_size
         ffn_multiplier = 2
 
-    d = _activation_dtype_bytes(activation_dtype)
+    d = get_safetensors_dtype_bytes(activation_dtype)
     T = max_num_batched_tokens
     S = min(T, batch_size)
 
@@ -186,21 +186,13 @@ def compute_safetensors_warmup_peak(
     lm_head_spike: int
     match model_class:
         case "causal_lm" | "conditional_gen":
-            vocab_size = config.get("vocab_size")
-            if not isinstance(vocab_size, int) or vocab_size <= 0:
-                warnings.warn(
-                    f"Warmup peak estimate skipped for `--model-id={model_id}`: "
-                    f"`config.json` missing `vocab_size` for a causal LM / VLM."
-                )
+            vocab_size = _resolve_vocab_size(config, model_id, "causal LM / VLM")
+            if vocab_size is None:
                 return None
             lm_head_spike = S * vocab_size * d
         case "masked_lm":
-            vocab_size = config.get("vocab_size")
-            if not isinstance(vocab_size, int) or vocab_size <= 0:
-                warnings.warn(
-                    f"Warmup peak estimate skipped for `--model-id={model_id}`: "
-                    f"`config.json` missing `vocab_size` for a masked LM."
-                )
+            vocab_size = _resolve_vocab_size(config, model_id, "masked LM")
+            if vocab_size is None:
                 return None
             lm_head_spike = T * vocab_size * d  # LM head applied to every token
         case "seq_classification":

--- a/src/hf_mem/safetensors/warmup_peak.py
+++ b/src/hf_mem/safetensors/warmup_peak.py
@@ -1,0 +1,106 @@
+import warnings
+from typing import Any, Dict, List, Literal
+
+from hf_mem.safetensors.types import get_safetensors_dtype_bytes, torch_dtype_to_safetensors_dtype
+
+ModelClass = Literal[
+    "causal_lm",
+    "conditional_gen",
+    "masked_lm",
+    "seq_classification",
+    "token_classification",
+    "base_encoder",
+]
+
+# Architecture-suffix → ModelClass. Matching is via `__contains__` (substring),
+# mirroring how run.py already detects ForCausalLM / ForConditionalGeneration.
+_ARCH_SUFFIX_MAP: list[tuple[str, ModelClass]] = [
+    # Order matters: more specific suffixes must come before less specific ones
+    # so that e.g. `BertForSequenceClassification` matches before `BertModel` would
+    # (it never does here since we only match the listed suffixes, but keep the
+    # discipline for future additions).
+    ("ForCausalLM", "causal_lm"),
+    ("ForConditionalGeneration", "conditional_gen"),
+    ("ForMaskedLM", "masked_lm"),
+    ("ForPreTraining", "masked_lm"),
+    ("ForSequenceClassification", "seq_classification"),
+    ("ForQuestionAnswering", "seq_classification"),
+    ("ForMultipleChoice", "seq_classification"),
+    ("ForTokenClassification", "token_classification"),
+]
+
+
+def classify_architecture(architectures: List[str], file_paths: List[str]) -> ModelClass | None:
+    """Map HF `config.architectures` to a ModelClass used by the warmup peak formula.
+
+    Returns None when no known suffix is found AND the repo is not a Sentence Transformers
+    model — in that case the caller should warn and skip the warmup peak estimate.
+    """
+    for arch in architectures or []:
+        for suffix, model_class in _ARCH_SUFFIX_MAP:
+            if suffix in arch:
+                return model_class
+
+    # Sentence Transformers and bare `…Model` (e.g. BertModel used as an encoder)
+    # both fall under "base_encoder". Sentence Transformers is identifiable via
+    # the presence of `config_sentence_transformers.json` in the repo.
+    if "config_sentence_transformers.json" in file_paths:
+        return "base_encoder"
+
+    # Bare `…Model` architectures (e.g. BertModel, RobertaModel, XLMRobertaModel) —
+    # only when the architecture string ends in "Model" without a head suffix.
+    for arch in architectures or []:
+        if arch.endswith("Model") and "ForCausalLM" not in arch and "ForConditionalGeneration" not in arch:
+            return "base_encoder"
+
+    return None
+
+
+def resolve_activation_dtype(config: Dict[str, Any]) -> str | None:
+    """Resolve the activation (compute) dtype for the warmup forward pass.
+
+    Returns a Safetensors dtype string (e.g. "BF16", "F16"), or None when it cannot
+    be determined. Caller should warn and skip warmup peak when None is returned.
+
+    Resolution order:
+      1. torch_dtype / dtype, if it is a non-quantized dtype.
+      2. If torch_dtype / dtype resolves to a quantized dtype (float8_*), assume bf16
+         as the dequantized compute dtype.
+      3. If quantization_config is present but no torch_dtype/dtype, assume bf16.
+      4. Otherwise None.
+    """
+    _QUANTIZED_TORCH_DTYPES = {"float8_e4m3", "float8_e4m3fn", "float8_e5m2", "int8"}
+
+    raw = config.get("torch_dtype") or config.get("dtype")
+    if isinstance(raw, str):
+        normalized = raw.replace("torch.", "")
+        if normalized in _QUANTIZED_TORCH_DTYPES:
+            return "BF16"  # dequantized compute dtype
+        return torch_dtype_to_safetensors_dtype(normalized)
+
+    if "quantization_config" in config:
+        return "BF16"
+
+    return None
+
+
+def _activation_dtype_bytes(dtype: str) -> int:
+    return get_safetensors_dtype_bytes(dtype)
+
+
+def _resolve_intermediate_size(config: Dict[str, Any]) -> int | None:
+    for key in ("intermediate_size", "ffn_dim", "n_inner"):
+        value = config.get(key)
+        if isinstance(value, int) and value > 0:
+            return value
+    return None
+
+
+def _resolve_num_labels(config: Dict[str, Any]) -> int | None:
+    value = config.get("num_labels")
+    if isinstance(value, int) and value > 0:
+        return value
+    id2label = config.get("id2label")
+    if isinstance(id2label, dict) and len(id2label) > 0:
+        return len(id2label)
+    return None

--- a/src/hf_mem/safetensors/warmup_peak.py
+++ b/src/hf_mem/safetensors/warmup_peak.py
@@ -56,18 +56,19 @@ def classify_architecture(architectures: List[str], file_paths: List[str]) -> Mo
     return None
 
 
-def resolve_activation_dtype(config: Dict[str, Any]) -> str | None:
+def resolve_activation_dtype(config: Dict[str, Any]) -> str:
     """Resolve the activation (compute) dtype for the warmup forward pass.
 
-    Returns a Safetensors dtype string (e.g. "BF16", "F16"), or None when it cannot
-    be determined. Caller should warn and skip warmup peak when None is returned.
+    Returns a Safetensors dtype string (e.g. "BF16", "F16", "F32"). Never returns
+    None — falls back to F32 (HuggingFace's default) when no dtype info is found.
 
     Resolution order:
       1. torch_dtype / dtype, if it is a non-quantized dtype.
       2. If torch_dtype / dtype resolves to a quantized dtype (float8_*), assume bf16
          as the dequantized compute dtype.
       3. If quantization_config is present but no torch_dtype/dtype, assume bf16.
-      4. Otherwise None.
+      4. Otherwise F32 — HuggingFace Transformers' default compute dtype when
+         torch_dtype / dtype is absent (common for older BERT-family models).
     """
     _QUANTIZED_TORCH_DTYPES = {"float8_e4m3", "float8_e4m3fn", "float8_e5m2", "int8"}
 
@@ -81,7 +82,9 @@ def resolve_activation_dtype(config: Dict[str, Any]) -> str | None:
     if "quantization_config" in config:
         return "BF16"
 
-    return None
+    # HuggingFace Transformers' default when torch_dtype / dtype absent is float32.
+    # Many older BERT-family / Sentence Transformers models don't set the field at all.
+    return "F32"
 
 
 def _activation_dtype_bytes(dtype: str) -> int:
@@ -138,13 +141,6 @@ def compute_safetensors_warmup_peak(
         return None
 
     activation_dtype = resolve_activation_dtype(config)
-    if activation_dtype is None:
-        warnings.warn(
-            f"Warmup peak estimate skipped for `--model-id={model_id}`: could not resolve "
-            f"the activation dtype from `config.json` (no `torch_dtype`, `dtype`, or "
-            f"`quantization_config` field present)."
-        )
-        return None
 
     required = ("hidden_size", "num_attention_heads")
     missing = [k for k in required if k not in config]

--- a/src/hf_mem/safetensors/warmup_peak.py
+++ b/src/hf_mem/safetensors/warmup_peak.py
@@ -104,3 +104,137 @@ def _resolve_num_labels(config: Dict[str, Any]) -> int | None:
     if isinstance(id2label, dict) and len(id2label) > 0:
         return len(id2label)
     return None
+
+
+from hf_mem._types import WarmupPeak
+
+
+def compute_safetensors_warmup_peak(
+    config: Dict[str, Any],
+    max_num_batched_tokens: int,
+    batch_size: int,
+    file_paths: List[str],
+    model_id: str,
+) -> WarmupPeak | None:
+    """Approximate the peak activation memory during one warmup forward pass.
+
+    Models what PyTorch's caching allocator holds: a persistent residual stream
+    of (T × H × d_act), plus the largest transient at any one point in the forward.
+
+    Returns None (with a warning) on any of:
+      - architecture not in the supported taxonomy
+      - required config keys missing
+      - activation dtype unresolvable
+      - classifier architecture without num_labels / id2label
+    """
+    architectures = config.get("architectures", []) or []
+    model_class = classify_architecture(architectures, file_paths)
+    if model_class is None:
+        warnings.warn(
+            f"Warmup peak estimate skipped for `--model-id={model_id}`: architecture(s) "
+            f"{architectures or '<missing>'} not in the supported taxonomy (causal LM, "
+            f"VLM, masked LM, classifier, base encoder / Sentence Transformers)."
+        )
+        return None
+
+    activation_dtype = resolve_activation_dtype(config)
+    if activation_dtype is None:
+        warnings.warn(
+            f"Warmup peak estimate skipped for `--model-id={model_id}`: could not resolve "
+            f"the activation dtype from `config.json` (no `torch_dtype`, `dtype`, or "
+            f"`quantization_config` field present)."
+        )
+        return None
+
+    required = ("hidden_size", "num_attention_heads")
+    missing = [k for k in required if k not in config]
+    if missing:
+        warnings.warn(
+            f"Warmup peak estimate skipped for `--model-id={model_id}`: `config.json` "
+            f"missing required keys: {missing}."
+        )
+        return None
+
+    intermediate_size = _resolve_intermediate_size(config)
+    if intermediate_size is None:
+        warnings.warn(
+            f"Warmup peak estimate skipped for `--model-id={model_id}`: could not resolve "
+            f"the FFN intermediate size from `config.json` (looked for `intermediate_size`, "
+            f"`ffn_dim`, `n_inner`)."
+        )
+        return None
+
+    hidden_size: int = config["hidden_size"]
+    num_attention_heads: int = config["num_attention_heads"]
+    num_key_value_heads: int = config.get("num_key_value_heads", num_attention_heads)
+    head_dim: int = config.get("head_dim", hidden_size // num_attention_heads)
+
+    # MoE adjustment: when num_experts_per_tok is present, the FFN transient is
+    # the per-token activation across active experts only.
+    num_experts_per_tok = config.get("num_experts_per_tok") or config.get("num_experts_per_token") or config.get("top_k")
+    moe_intermediate_size = config.get("moe_intermediate_size")
+    if isinstance(num_experts_per_tok, int) and num_experts_per_tok > 0:
+        ffn_width = moe_intermediate_size if isinstance(moe_intermediate_size, int) else intermediate_size
+        ffn_multiplier = 2 * num_experts_per_tok
+    else:
+        ffn_width = intermediate_size
+        ffn_multiplier = 2
+
+    d = _activation_dtype_bytes(activation_dtype)
+    T = max_num_batched_tokens
+    S = min(T, batch_size)
+
+    residual_stream = T * hidden_size * d
+    attn_transient = T * (num_attention_heads + 2 * num_key_value_heads) * head_dim * d
+    ffn_transient = ffn_multiplier * T * ffn_width * d
+
+    # Terminal "head" spike — model-class-dependent.
+    lm_head_spike: int
+    match model_class:
+        case "causal_lm" | "conditional_gen":
+            vocab_size = config.get("vocab_size")
+            if not isinstance(vocab_size, int) or vocab_size <= 0:
+                warnings.warn(
+                    f"Warmup peak estimate skipped for `--model-id={model_id}`: "
+                    f"`config.json` missing `vocab_size` for a causal LM / VLM."
+                )
+                return None
+            lm_head_spike = S * vocab_size * d
+        case "masked_lm":
+            vocab_size = config.get("vocab_size")
+            if not isinstance(vocab_size, int) or vocab_size <= 0:
+                warnings.warn(
+                    f"Warmup peak estimate skipped for `--model-id={model_id}`: "
+                    f"`config.json` missing `vocab_size` for a masked LM."
+                )
+                return None
+            lm_head_spike = T * vocab_size * d  # LM head applied to every token
+        case "seq_classification":
+            num_labels = _resolve_num_labels(config)
+            if num_labels is None:
+                warnings.warn(
+                    f"Warmup peak estimate skipped for `--model-id={model_id}`: classifier "
+                    f"architecture without `num_labels` or `id2label` in `config.json`."
+                )
+                return None
+            lm_head_spike = S * num_labels * d
+        case "token_classification":
+            num_labels = _resolve_num_labels(config)
+            if num_labels is None:
+                warnings.warn(
+                    f"Warmup peak estimate skipped for `--model-id={model_id}`: classifier "
+                    f"architecture without `num_labels` or `id2label` in `config.json`."
+                )
+                return None
+            lm_head_spike = T * num_labels * d
+        case "base_encoder":
+            lm_head_spike = S * hidden_size * d
+
+    peak_bytes = residual_stream + max(attn_transient, ffn_transient, lm_head_spike)
+
+    return WarmupPeak(
+        max_num_batched_tokens=T,
+        max_num_seqs=S,
+        peak_bytes=peak_bytes,
+        activation_dtype=activation_dtype,
+    )


### PR DESCRIPTION
## Summary

- Adds an opt-in `--max-num-batched-tokens` flag that estimates the **peak activation memory** during a single warmup forward pass for Safetensors models — analogous to what vLLM measures in `profile_run` and TEI measures during its warmup.
- Reports `warmup_peak` as a new memory component alongside the existing weights and KV cache, and includes it in `total_memory`.
- Supports causal LMs, conditional generation (VLMs), masked LMs, sequence/token classifiers, base encoders, and Sentence Transformers. Independent of `--experimental` — works on its own.

## Why

`hf-mem` already reports weights and (under `--experimental`) KV cache. A user trying to decide whether a model fits on a given GPU still has to guess the activation overhead, which can be a large fraction of total reserved memory — particularly for models with large vocab (LM head logits at the end of the forward pass) or wide FFNs. Inference engines (vLLM, TEI) measure this directly at startup; this PR produces a closed-form approximation from `config.json` metadata alone, no GPU required.

## What it computes

For each forward-pass phase, the formula models PyTorch's caching allocator (a persistent residual stream + the largest transient at any one point):

- `residual_stream = T × hidden_size × d`
- `attn_transient = T × (num_q_heads + 2·num_kv_heads) × head_dim × d`
- `ffn_transient = 2 × T × intermediate_size × d` (× `num_experts_per_tok` for MoE)
- `lm_head_spike`: model-class-dependent
  - causal LM / VLM: `S × vocab_size × d`
  - masked LM: `T × vocab_size × d` (LM head applied to every token, not just the last)
  - seq classifier: `S × num_labels × d`
  - token classifier: `T × num_labels × d`
  - base encoder / Sentence Transformers: `S × hidden_size × d`
- `peak = residual_stream + max(attn_transient, ffn_transient, lm_head_spike)`

`T = max_num_batched_tokens`, `S = min(T, batch_size)`, `d = activation dtype bytes`. The activation dtype is resolved from `config.json` (`torch_dtype` / `dtype`, falling back to F32 for older configs like BERT that don't set it; bf16 for quantized models since vLLM/TEI dequantize for compute).

Formula was derived by reading the actual vLLM V1 worker (`vllm/v1/worker/gpu_worker.py:388-416` for the profile_run accounting, `gpu_model_runner.py:5408-5431` for the token splitting that gives `S = min(T, max_num_seqs)`), TEI's warmup pass, and llama.cpp (`src/llama-context.cpp:551-612`) to confirm GGUF doesn't have a closed-form equivalent.

## Sample output

```
~/dev/os-help/hf-mem vrdn-23/add-warmup-peak-memory = ?3 ❯ uv run hf-mem --model-id HuggingFaceTB/SmolLM2-135M --experimental --max-num-batched-tokens 8192                                                                                                                                                                                                                                                                                                                                                                                                                      10:21:12
/Users/vidamoda/dev/os-help/hf-mem/src/hf_mem/cli.py:135: UserWarning: `--experimental` is set, which means that models with an architecture as `...ForCausalLM` and `...ForConditionalGeneration` will include estimations for the KV Cache as well. You can also provide the args `--max-model-len` and `--batch-size` as part of the estimation. Note that enabling `--experimental` means that the output will be different both when displayed and when dumped as JSON with `--json-output`, so bear that in mind. Warmup peak activation memory is controlled separately via `--max-num-batched-tokens`.
  warnings.warn(
/Users/vidamoda/dev/os-help/hf-mem/src/hf_mem/safetensors/print.py:133: UserWarning: Given that the provided `--model-id HuggingFaceTB/SmolLM2-135M` (with `--revision main`) is longer than 64 characters, the table width will be expanded to fit the provided values within their row, but it might lead to unexpected table views.
  warnings.warn(
┌┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬┬ hf-mem v0.5.5 ┐
├┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┴┤
│                        INFERENCE MEMORY ESTIMATE FOR                        │
│               https://hf.co/HuggingFaceTB/SmolLM2-135M @ main               │
│                     w/ max-model-len=8192, batch-size=1                     │
│                w/ max-num-batched-tokens=8192, batch-size=1                 │
├────────────────┬────────────────────────────────────────────────────────────┤
│ TOTAL MEMORY   │ 0.48 GiB (134.52M PARAMS + KV CACHE + WARMUP PEAK)         │
│ REQUIREMENTS   │ ██████████████████████████████████████████████████████████ │
├────────────────┴────────────────────────────────────────────────────────────┤
│                      MODEL (134.52M PARAMS, 0.25 GiB)                       │
├────────────────┬────────────────────────────────────────────────────────────┤
│ BF16           │ 0.25 / 0.48 GiB                                            │
│ 134.52M PARAMS │ ██████████████████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░ │
├────────────────┴────────────────────────────────────────────────────────────┤
│                      KV CACHE (8192 TOKENS, 0.18 GiB)                       │
├────────────────┬────────────────────────────────────────────────────────────┤
│ BF16           │ 0.18 / 0.48 GiB                                            │
│ 8192 TOKENS    │ █████████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ │
├────────────────┴────────────────────────────────────────────────────────────┤
│                     WARMUP PEAK (8192 TOKENS, 0.06 GiB)                     │
├────────────────┬────────────────────────────────────────────────────────────┤
│ BF16           │ 0.06 / 0.48 GiB                                            │
│ 8192 TOKENS    │ ███████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ │
└────────────────┴────────────────────────────────────────────────────────────┘
~/d/o/hf-mem vrdn-23/add-warmup-peak-memory = ?3 ❯ 
```

JSON shape: `{"memory": ..., "kv_cache": ..., "warmup_peak": ..., "total_memory": ...}` (with `warmup_peak` omitted when the flag isn't set, so default behavior is unchanged).

## Out of scope

- **GGUF**: llama.cpp's compute buffer size is determined at runtime by `ggml_backend_sched_get_buffer_size` after building the actual ggml graph; there is no closed-form formula derivable from GGUF metadata. The flag is silently a no-op for GGUF files (emits a clear warning).
- **`non_torch_increase`**: NCCL buffers, FlashAttention kernel workspaces, CUDA staging — only knowable at runtime. The estimate models `torch_peak_increase` only; real-world peak is typically a bit higher, especially in multi-GPU deployments.
- **Tensor parallelism**: out of scope (would divide most terms by world size).
- **Per-component breakdown** (residual / attn / ffn / lm_head) in `--details` JSON — deferred; the internal `WarmupPeak` dataclass is designed so adding it later doesn't break the public API.

## Implementation notes

- New module: `src/hf_mem/safetensors/warmup_peak.py` (pure functions; no I/O).
- New dataclass: `WarmupPeak` in `_types.py` (mirrors `KvCache` style).
- `Result` gains `warmup_peak: int | None` (parallel to `kv_cache`) and `warmup_peak_metadata: WarmupPeak | None` (parallel to `kv_cache_metadata`).
- `run.py`'s experimental block was refactored to fetch `config.json` once whether one or both estimates are requested. The `ForConditionalGeneration` `text_config` swap was lifted out of the experimental-only branch so warmup peak benefits from it too.
- `--batch-size` is reused as `max_num_seqs` (the same physical concurrency that drives both KV cache sizing in vLLM and the LM head spike during warmup); no new flag for that.

## Test plan

- [x] Causal LM (`HuggingFaceTB/SmolLM2-135M`): `--max-num-batched-tokens 8192` produces `WARMUP PEAK` block + positive `warmup_peak` in JSON.
- [x] Combined `--experimental` + `--max-num-batched-tokens` renders both KV CACHE and WARMUP PEAK blocks; `total_memory = weights + kv_cache + warmup_peak`.
- [x] VLM (`Qwen/Qwen2-VL-2B-Instruct`) with `--experimental` correctly reports both KV cache and warmup peak (text_config swap correctly preserved).
- [x] Masked LM (`bert-base-uncased`): `T × vocab_size` term dominates (~978 MiB at T=8192 in F32 fallback).
- [x] Sentence Transformers (`sentence-transformers/all-MiniLM-L6-v2`) and cross-encoder (`cross-encoder/ms-marco-MiniLM-L-6-v2`) detected as encoders; FFN transient dominates.
- [x] MoE (`Qwen/Qwen2.5-7B-Instruct`, etc.) — `num_experts_per_tok` correctly scales the FFN transient.
- [x] GGUF (`TheBloke/deepseek-llm-7B-chat-GGUF`) emits a no-op warning and skips warmup peak; existing GGUF behavior unchanged.
- [x] Negative `--max-num-batched-tokens` raises a clear `RuntimeError`.
- [x] No flag passed → no `warmup_peak` field in output (default behavior unchanged for existing users).
- [ ] (Optional, GPU-only) Comparison against an actual vLLM `profile_run` log on a reference model — left for follow-up; not blocking.

---

Draft for early review. Will mark ready once the test plan's optional GPU comparison is done (or omitted, depending on feedback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)