### PR TITLE
Percent-encode `--revision` in Hub URLs

### DIFF
--- a/src/hf_mem/_fetch.py
+++ b/src/hf_mem/_fetch.py
@@ -1,10 +1,17 @@
 import os
 from typing import Any, Dict
+from urllib.parse import quote
 
 import httpx
 
 # NOTE: Shared across all HTTP fetch operations; overridable via the `REQUEST_TIMEOUT` environment variable
 REQUEST_TIMEOUT = float(os.getenv("REQUEST_TIMEOUT", 30.0))
+
+
+# NOTE: Revisions like `refs/pr/4` contain slashes that must be percent-encoded so the Hub API
+# treats them as a single path segment instead of extra path components.
+def quote_revision(revision: str) -> str:
+    return quote(revision, safe="")
 
 
 # NOTE: Return type-hint set to `Any`, but it will only be a JSON-compatible object

--- a/src/hf_mem/_fetch.py
+++ b/src/hf_mem/_fetch.py
@@ -1,17 +1,10 @@
 import os
 from typing import Any, Dict
-from urllib.parse import quote
 
 import httpx
 
 # NOTE: Shared across all HTTP fetch operations; overridable via the `REQUEST_TIMEOUT` environment variable
 REQUEST_TIMEOUT = float(os.getenv("REQUEST_TIMEOUT", 30.0))
-
-
-# NOTE: Revisions like `refs/pr/4` contain slashes that must be percent-encoded so the Hub API
-# treats them as a single path segment instead of extra path components.
-def quote_revision(revision: str) -> str:
-    return quote(revision, safe="")
 
 
 # NOTE: Return type-hint set to `Any`, but it will only be a JSON-compatible object

--- a/src/hf_mem/gguf/fetch.py
+++ b/src/hf_mem/gguf/fetch.py
@@ -5,7 +5,7 @@ from typing import Dict, Tuple
 
 import httpx
 
-from hf_mem._fetch import REQUEST_TIMEOUT
+from hf_mem._fetch import REQUEST_TIMEOUT, quote_revision
 from hf_mem.gguf.metadata import GGUFMetadata, parse_gguf_metadata
 
 # NOTE: Start with 1 MB; this is sufficient for the metadata of most GGUF models.
@@ -67,7 +67,7 @@ async def fetch_gguf_with_semaphore(
     async with semaphore:
         metadata = await fetch_gguf_metadata(
             client=client,
-            url=f"https://huggingface.co/{model_id}/resolve/{revision}/{path}",
+            url=f"https://huggingface.co/{model_id}/resolve/{quote_revision(revision)}/{path}",
             experimental=parse_kv_cache,
             max_model_len=max_model_len,
             kv_cache_dtype=kv_cache_dtype,

--- a/src/hf_mem/gguf/fetch.py
+++ b/src/hf_mem/gguf/fetch.py
@@ -5,7 +5,7 @@ from typing import Dict, Tuple
 
 import httpx
 
-from hf_mem._fetch import REQUEST_TIMEOUT, quote_revision
+from hf_mem._fetch import REQUEST_TIMEOUT
 from hf_mem.gguf.metadata import GGUFMetadata, parse_gguf_metadata
 
 # NOTE: Start with 1 MB; this is sufficient for the metadata of most GGUF models.
@@ -55,7 +55,7 @@ async def fetch_gguf_with_semaphore(
     semaphore: asyncio.Semaphore,
     client: httpx.AsyncClient,
     model_id: str,
-    revision: str,
+    revision_encoded: str,
     path: str,
     parse_kv_cache: bool,
     shard_pattern: re.Match | None,
@@ -67,7 +67,7 @@ async def fetch_gguf_with_semaphore(
     async with semaphore:
         metadata = await fetch_gguf_metadata(
             client=client,
-            url=f"https://huggingface.co/{model_id}/resolve/{quote_revision(revision)}/{path}",
+            url=f"https://huggingface.co/{model_id}/resolve/{revision_encoded}/{path}",
             experimental=parse_kv_cache,
             max_model_len=max_model_len,
             kv_cache_dtype=kv_cache_dtype,

--- a/src/hf_mem/run.py
+++ b/src/hf_mem/run.py
@@ -5,11 +5,12 @@ import warnings
 from dataclasses import dataclass, field
 from functools import reduce
 from typing import Any, Dict, List, Tuple, Union
+from urllib.parse import quote
 from uuid import uuid4
 
 import httpx
 
-from hf_mem._fetch import get_json_file, quote_revision
+from hf_mem._fetch import get_json_file
 from hf_mem._types import KvCache
 from hf_mem._version import __version__
 from hf_mem.gguf.fetch import fetch_gguf_with_semaphore
@@ -218,6 +219,11 @@ async def arun(
     gguf_file: str | None = None,
     details: bool = False,
 ) -> Result:
+    # NOTE: Revisions like `refs/pr/4` contain slashes (and branches may contain `#`, spaces, etc.)
+    # that must be percent-encoded so the Hub API treats the revision as a single path segment.
+    # Keep the raw `revision` for display (User-Agent, error messages, `Result.revision`).
+    revision_encoded = quote(revision, safe="")
+
     headers: Dict[str, str] = {
         "User-Agent": f"hf-mem/{__version__}; id={uuid4()}; model_id={model_id}; revision={revision}"
     }
@@ -252,7 +258,7 @@ async def arun(
         http2=True,
         follow_redirects=True,
     )
-    url = f"https://huggingface.co/api/models/{model_id}/tree/{quote_revision(revision)}?recursive=true"
+    url = f"https://huggingface.co/api/models/{model_id}/tree/{revision_encoded}?recursive=true"
     files = await get_json_file(client=client, url=url, headers=headers)
     file_paths = [f["path"] for f in files if f.get("path") and f.get("type") == "file"]
 
@@ -310,7 +316,7 @@ async def arun(
                         semaphore=semaphore,
                         client=client,
                         model_id=model_id,
-                        revision=revision,
+                        revision_encoded=revision_encoded,
                         path=path,
                         parse_kv_cache=parse_kv_cache,
                         shard_pattern=shard_pattern,
@@ -365,7 +371,7 @@ async def arun(
             )
 
     if "model.safetensors" in file_paths:
-        url = f"https://huggingface.co/{model_id}/resolve/{quote_revision(revision)}/model.safetensors"
+        url = f"https://huggingface.co/{model_id}/resolve/{revision_encoded}/model.safetensors"
         raw_metadata = await fetch_safetensors_metadata(client=client, url=url, headers=headers)
 
         if "config_sentence_transformers.json" in file_paths:
@@ -374,7 +380,7 @@ async def arun(
                 if "modules.json" not in file_paths
                 else await fetch_modules_and_dense_metadata(
                     client=client,
-                    url=f"https://huggingface.co/{model_id}/resolve/{quote_revision(revision)}",
+                    url=f"https://huggingface.co/{model_id}/resolve/{revision_encoded}",
                     headers=headers,
                 )
             )
@@ -389,13 +395,11 @@ async def arun(
     elif "model.safetensors.index.json" in file_paths:
         # TODO: We could eventually skip this request in favour of a greedy approach on trying to pull all the
         # files following the formatting `model-00000-of-00000.safetensors`
-        url = (
-            f"https://huggingface.co/{model_id}/resolve/{quote_revision(revision)}/model.safetensors.index.json"
-        )
+        url = f"https://huggingface.co/{model_id}/resolve/{revision_encoded}/model.safetensors.index.json"
         files_index = await get_json_file(client=client, url=url, headers=headers)
 
         urls = {
-            f"https://huggingface.co/{model_id}/resolve/{quote_revision(revision)}/{f}"
+            f"https://huggingface.co/{model_id}/resolve/{revision_encoded}/{f}"
             for f in set(files_index["weight_map"].values())
         }
 
@@ -416,7 +420,7 @@ async def arun(
                 if "modules.json" not in file_paths
                 else await fetch_modules_and_dense_metadata(
                     client=client,
-                    url=f"https://huggingface.co/{model_id}/resolve/{quote_revision(revision)}",
+                    url=f"https://huggingface.co/{model_id}/resolve/{revision_encoded}",
                     headers=headers,
                 )
             )
@@ -427,7 +431,7 @@ async def arun(
         metadata = parse_safetensors_metadata(raw_metadata=raw_metadata)
 
     elif "model_index.json" in file_paths:
-        url = f"https://huggingface.co/{model_id}/resolve/{quote_revision(revision)}/model_index.json"
+        url = f"https://huggingface.co/{model_id}/resolve/{revision_encoded}/model_index.json"
         files_index = await get_json_file(client=client, url=url, headers=headers)
         paths = {k for k, _ in files_index.items() if not k.startswith("_")}
 
@@ -435,24 +439,24 @@ async def arun(
         for path in paths:
             if f"{path}/diffusion_pytorch_model.safetensors" in file_paths:
                 path_urls[path] = [
-                    f"https://huggingface.co/{model_id}/resolve/{quote_revision(revision)}/{path}/diffusion_pytorch_model.safetensors"
+                    f"https://huggingface.co/{model_id}/resolve/{revision_encoded}/{path}/diffusion_pytorch_model.safetensors"
                 ]
             elif f"{path}/model.safetensors" in file_paths:
                 path_urls[path] = [
-                    f"https://huggingface.co/{model_id}/resolve/{quote_revision(revision)}/{path}/model.safetensors"
+                    f"https://huggingface.co/{model_id}/resolve/{revision_encoded}/{path}/model.safetensors"
                 ]
             elif f"{path}/diffusion_pytorch_model.safetensors.index.json" in file_paths:
-                url = f"https://huggingface.co/{model_id}/resolve/{quote_revision(revision)}/{path}/diffusion_pytorch_model.safetensors.index.json"
+                url = f"https://huggingface.co/{model_id}/resolve/{revision_encoded}/{path}/diffusion_pytorch_model.safetensors.index.json"
                 files_index = await get_json_file(client=client, url=url, headers=headers)
                 path_urls[path] = [
-                    f"https://huggingface.co/{model_id}/resolve/{quote_revision(revision)}/{path}/{f}"
+                    f"https://huggingface.co/{model_id}/resolve/{revision_encoded}/{path}/{f}"
                     for f in set(files_index["weight_map"].values())
                 ]
             elif f"{path}/model.safetensors.index.json" in file_paths:
-                url = f"https://huggingface.co/{model_id}/resolve/{quote_revision(revision)}/{path}/model.safetensors.index.json"
+                url = f"https://huggingface.co/{model_id}/resolve/{revision_encoded}/{path}/model.safetensors.index.json"
                 files_index = await get_json_file(client=client, url=url, headers=headers)
                 path_urls[path] = [
-                    f"https://huggingface.co/{model_id}/resolve/{quote_revision(revision)}/{path}/{f}"
+                    f"https://huggingface.co/{model_id}/resolve/{revision_encoded}/{path}/{f}"
                     for f in set(files_index["weight_map"].values())
                 ]
 
@@ -486,7 +490,7 @@ async def arun(
     kv_cache_cls: KvCache | None = None
     moe_metadata: MoEMetadata | None = None
     if experimental and "config.json" in file_paths:
-        url = f"https://huggingface.co/{model_id}/resolve/{quote_revision(revision)}/config.json"
+        url = f"https://huggingface.co/{model_id}/resolve/{revision_encoded}/config.json"
         config: Dict[str, Any] = await get_json_file(client, url, headers)
 
         if not any(
@@ -507,7 +511,9 @@ async def arun(
                 text_config = config["text_config"]
 
                 if referenced_model := text_config.get("_name_or_path"):
-                    referenced_url = f"https://huggingface.co/{referenced_model}/resolve/{quote_revision(revision)}/config.json"
+                    referenced_url = (
+                        f"https://huggingface.co/{referenced_model}/resolve/{revision_encoded}/config.json"
+                    )
                     warnings.warn(
                         f"The `text_config` contains `_name_or_path={referenced_model}`, so fetching the config from `{referenced_model}` to retrieve the required fields for KV cache estimation."
                     )

--- a/src/hf_mem/run.py
+++ b/src/hf_mem/run.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 
 import httpx
 
-from hf_mem._fetch import get_json_file
+from hf_mem._fetch import get_json_file, quote_revision
 from hf_mem._types import KvCache
 from hf_mem._version import __version__
 from hf_mem.gguf.fetch import fetch_gguf_with_semaphore
@@ -252,7 +252,7 @@ async def arun(
         http2=True,
         follow_redirects=True,
     )
-    url = f"https://huggingface.co/api/models/{model_id}/tree/{revision}?recursive=true"
+    url = f"https://huggingface.co/api/models/{model_id}/tree/{quote_revision(revision)}?recursive=true"
     files = await get_json_file(client=client, url=url, headers=headers)
     file_paths = [f["path"] for f in files if f.get("path") and f.get("type") == "file"]
 
@@ -365,7 +365,7 @@ async def arun(
             )
 
     if "model.safetensors" in file_paths:
-        url = f"https://huggingface.co/{model_id}/resolve/{revision}/model.safetensors"
+        url = f"https://huggingface.co/{model_id}/resolve/{quote_revision(revision)}/model.safetensors"
         raw_metadata = await fetch_safetensors_metadata(client=client, url=url, headers=headers)
 
         if "config_sentence_transformers.json" in file_paths:
@@ -374,7 +374,7 @@ async def arun(
                 if "modules.json" not in file_paths
                 else await fetch_modules_and_dense_metadata(
                     client=client,
-                    url=f"https://huggingface.co/{model_id}/resolve/{revision}",
+                    url=f"https://huggingface.co/{model_id}/resolve/{quote_revision(revision)}",
                     headers=headers,
                 )
             )
@@ -389,11 +389,13 @@ async def arun(
     elif "model.safetensors.index.json" in file_paths:
         # TODO: We could eventually skip this request in favour of a greedy approach on trying to pull all the
         # files following the formatting `model-00000-of-00000.safetensors`
-        url = f"https://huggingface.co/{model_id}/resolve/{revision}/model.safetensors.index.json"
+        url = (
+            f"https://huggingface.co/{model_id}/resolve/{quote_revision(revision)}/model.safetensors.index.json"
+        )
         files_index = await get_json_file(client=client, url=url, headers=headers)
 
         urls = {
-            f"https://huggingface.co/{model_id}/resolve/{revision}/{f}"
+            f"https://huggingface.co/{model_id}/resolve/{quote_revision(revision)}/{f}"
             for f in set(files_index["weight_map"].values())
         }
 
@@ -414,7 +416,7 @@ async def arun(
                 if "modules.json" not in file_paths
                 else await fetch_modules_and_dense_metadata(
                     client=client,
-                    url=f"https://huggingface.co/{model_id}/resolve/{revision}",
+                    url=f"https://huggingface.co/{model_id}/resolve/{quote_revision(revision)}",
                     headers=headers,
                 )
             )
@@ -425,7 +427,7 @@ async def arun(
         metadata = parse_safetensors_metadata(raw_metadata=raw_metadata)
 
     elif "model_index.json" in file_paths:
-        url = f"https://huggingface.co/{model_id}/resolve/{revision}/model_index.json"
+        url = f"https://huggingface.co/{model_id}/resolve/{quote_revision(revision)}/model_index.json"
         files_index = await get_json_file(client=client, url=url, headers=headers)
         paths = {k for k, _ in files_index.items() if not k.startswith("_")}
 
@@ -433,26 +435,24 @@ async def arun(
         for path in paths:
             if f"{path}/diffusion_pytorch_model.safetensors" in file_paths:
                 path_urls[path] = [
-                    f"https://huggingface.co/{model_id}/resolve/{revision}/{path}/diffusion_pytorch_model.safetensors"
+                    f"https://huggingface.co/{model_id}/resolve/{quote_revision(revision)}/{path}/diffusion_pytorch_model.safetensors"
                 ]
             elif f"{path}/model.safetensors" in file_paths:
                 path_urls[path] = [
-                    f"https://huggingface.co/{model_id}/resolve/{revision}/{path}/model.safetensors"
+                    f"https://huggingface.co/{model_id}/resolve/{quote_revision(revision)}/{path}/model.safetensors"
                 ]
             elif f"{path}/diffusion_pytorch_model.safetensors.index.json" in file_paths:
-                url = f"https://huggingface.co/{model_id}/resolve/{revision}/{path}/diffusion_pytorch_model.safetensors.index.json"
+                url = f"https://huggingface.co/{model_id}/resolve/{quote_revision(revision)}/{path}/diffusion_pytorch_model.safetensors.index.json"
                 files_index = await get_json_file(client=client, url=url, headers=headers)
                 path_urls[path] = [
-                    f"https://huggingface.co/{model_id}/resolve/{revision}/{path}/{f}"
+                    f"https://huggingface.co/{model_id}/resolve/{quote_revision(revision)}/{path}/{f}"
                     for f in set(files_index["weight_map"].values())
                 ]
             elif f"{path}/model.safetensors.index.json" in file_paths:
-                url = (
-                    f"https://huggingface.co/{model_id}/resolve/{revision}/{path}/model.safetensors.index.json"
-                )
+                url = f"https://huggingface.co/{model_id}/resolve/{quote_revision(revision)}/{path}/model.safetensors.index.json"
                 files_index = await get_json_file(client=client, url=url, headers=headers)
                 path_urls[path] = [
-                    f"https://huggingface.co/{model_id}/resolve/{revision}/{path}/{f}"
+                    f"https://huggingface.co/{model_id}/resolve/{quote_revision(revision)}/{path}/{f}"
                     for f in set(files_index["weight_map"].values())
                 ]
 
@@ -486,7 +486,7 @@ async def arun(
     kv_cache_cls: KvCache | None = None
     moe_metadata: MoEMetadata | None = None
     if experimental and "config.json" in file_paths:
-        url = f"https://huggingface.co/{model_id}/resolve/{revision}/config.json"
+        url = f"https://huggingface.co/{model_id}/resolve/{quote_revision(revision)}/config.json"
         config: Dict[str, Any] = await get_json_file(client, url, headers)
 
         if not any(
@@ -507,7 +507,7 @@ async def arun(
                 text_config = config["text_config"]
 
                 if referenced_model := text_config.get("_name_or_path"):
-                    referenced_url = f"https://huggingface.co/{referenced_model}/resolve/{revision}/config.json"
+                    referenced_url = f"https://huggingface.co/{referenced_model}/resolve/{quote_revision(revision)}/config.json"
                     warnings.warn(
                         f"The `text_config` contains `_name_or_path={referenced_model}`, so fetching the config from `{referenced_model}` to retrieve the required fields for KV cache estimation."
                     )


### PR DESCRIPTION
## Summary

`hf-mem` fails with a 404 when `--revision` contains slashes (PR refs like `refs/pr/4`, branches with `/` in the name, etc.). The revision was being interpolated directly into Hub URLs, so the slashes were parsed as extra path segments by the API.

### Repro

```
$ uvx hf-mem --model-id unitary/unbiased-toxic-roberta --revision refs/pr/4
httpx.HTTPStatusError: Client error '404 Not Found' for url
'https://huggingface.co/api/models/unitary/unbiased-toxic-roberta/tree/refs/pr/4?recursive=true'
```

The same revision works in a browser at `https://huggingface.co/unitary/unbiased-toxic-roberta/tree/refs%2Fpr%2F4` because the Hub UI percent-encodes the slashes. Both the `api/models/.../tree/{rev}` and `.../resolve/{rev}/...` endpoints require the revision to be a single URL path segment — `refs/pr/4` must be sent as `refs%2Fpr%2F4`, otherwise the route resolves to a non-existent ref called `refs`.

### Fix

Add a small `quote_revision()` helper in `_fetch.py` that wraps `urllib.parse.quote(revision, safe="")`, and use it at every `{revision}` interpolation site in `run.py` and `gguf/fetch.py`. Display strings (table headers, log messages, `Result.revision`) keep the raw value so output still reads `@ refs/pr/4`.

## Test plan

- [x] `uvx hf-mem --model-id unitary/unbiased-toxic-roberta --revision refs/pr/4` succeeds and reports `0.46 GiB / 124.66M params`
- [x] `uvx hf-mem --model-id bert-base-uncased` (default `main`) still works — no regression for revisions without slashes
- [ ] Optional: spot-check a GGUF model and an `--experimental` run on a non-default revision

🤖 Generated with [Claude Code](https://claude.com/claude-code)