### PR TITLE
Reserve full-size KV for sliding layers in hybrid models

### DIFF
--- a/src/hf_mem/safetensors/kv_cache.py
+++ b/src/hf_mem/safetensors/kv_cache.py
@@ -157,13 +157,17 @@ def compute_safetensors_kv_cache_size(
     # making the fallback `hidden_size // num_attention_heads` incorrect for those models
     head_dim: int = config.get("head_dim", hidden_size // num_attention_heads)
 
-    # NOTE: For hybrid attention models full-attention layers grow with `max_model_len` while
-    # sliding-window layers reuse a fixed-size buffer capped at `sliding_window`; so we sum the
-    # per-layer token counts (`max_model_len` for full-attention, `min(sliding_window, max_model_len)`
-    # for sliding-window) instead of multiplying a single layer count by `max_model_len`.
+    # NOTE: Full-attention layers always grow with `max_model_len`. Sliding-window layers depend
+    # on the regime: in a *hybrid* model (mix of full + sliding layers) inference engines commonly
+    # unify KV page sizes across layer groups, so sliding layers reserve full-size pages and
+    # effectively cost `max_model_len` tokens too; in a *pure* sliding-window model they stay capped
+    # at `min(sliding_window, max_model_len)`. We report the reserved (upper-bound) footprint so the
+    # estimate does not under-count what actually gets allocated for long contexts.
     num_full_layers, num_sliding_layers = _resolve_attention_layer_counts(config)
     sliding_window = config.get("sliding_window") or max_model_len
-    total_kv_tokens = num_full_layers * max_model_len + num_sliding_layers * min(sliding_window, max_model_len)
+    is_hybrid = num_full_layers > 0 and num_sliding_layers > 0
+    sliding_tokens = max_model_len if is_hybrid else min(sliding_window, max_model_len)
+    total_kv_tokens = num_full_layers * max_model_len + num_sliding_layers * sliding_tokens
 
     return (
         # NOTE: 2 because it applies to both key and value projections


### PR DESCRIPTION
## Description

**What:** hf-mem caps every sliding-window layer at `min(sliding_window, max_model_len)` when estimating KV cache. That is correct for a **pure** sliding-window model, but under-counts for a **hybrid** model that mixes full-attention and sliding-window layers (e.g. `openai/gpt-oss-20b`/`-120b`, Gemma).

In hybrid models, inference engines unify KV page sizes across layer groups: the sliding-window layers reserve **full-size pages**, so they effectively cost `max_model_len` tokens, not `sliding_window`. The current formula reports a best-case *lower bound* rather than what actually gets allocated.

**Why:** As a memory-budgeting tool, under-counting is the dangerous direction — it says a config fits when it will OOM. The gap only appears when `max_model_len > sliding_window`, which is the common long-context case for these popular models.

For `openai/gpt-oss-20b` at `max_model_len=8192`, `batch_size=32`, BF16 KV:

| | KV cache |
|---|---:|
| before (`min(window, len)`) | 6.09 GiB |
| after (hybrid → full) | 12.00 GiB |
| under-count | **-49.22%** |

This is distinct from #61: that correctly counted sliding layers but validated the regime where context length did **not** exceed the sliding window. Long-context allocation was still under-counted.

**The change** (5 lines, no new deps, no new abstractions):

```python
num_full_layers, num_sliding_layers = _resolve_attention_layer_counts(config)
sliding_window = config.get("sliding_window") or max_model_len
is_hybrid = num_full_layers > 0 and num_sliding_layers > 0
sliding_tokens = max_model_len if is_hybrid else min(sliding_window, max_model_len)
total_kv_tokens = num_full_layers * max_model_len + num_sliding_layers * sliding_tokens
```

- **Hybrid** (full + sliding): sliding layers cost `max_model_len`.
- **Pure sliding-window** and **pure full-attention**: unchanged. When `max_model_len <= sliding_window`, `min()` already returns `max_model_len`, so short-context estimates are unaffected — only the hybrid + long-context regime changes.

**Testing:** installed locally (`uv pip install -e .`), ran against `openai/gpt-oss-20b` — layer detection resolves 12 full + 12 sliding (window 128), producing the 6.09 → 12.00 GiB change. Verified pure-SWA and pure-full configs are unchanged. `ruff`/pre-commit pass.

**AI assistance:** this change was developed with AI assistance (Claude), disclosed per `CONTRIBUTING.md`. I have reviewed and understand every line and can defend the change end to end. Happy to adjust the approach — e.g. gate the upper-bound behind a flag or report both bounds — if you'd prefer.

---

- [x] I have read and followed the guidelines in [`CONTRIBUTING.md`](/CONTRIBUTING.md).
- [ ] This has been discussed over an issue or discussion. *(Opening directly for visibility — happy to move discussion to an issue first if you prefer.)*